### PR TITLE
Refactor JS to remove Handlebars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +142,7 @@ version = "0.5.3"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "htmlescape 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-format 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-stemmers 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -226,6 +232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+"checksum htmlescape 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 console_error_panic_hook = "0.1.6"
 num-format = "0.4.0"
 rust-stemmers = "1.2.0"
+htmlescape = "0.3.1"
 
 [dependencies.wasm-bindgen]
 version = "^0.2"

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,17 @@
+export const defaultConfig = {
+  showProgress: true,
+  printIndexInfo: false,
+  showScores: false
+};
+
+export function calculateOverriddenConfig(original, overrides) {
+  const output = Object.create({});
+  Object.keys(original).forEach(key => {
+    if (key in overrides) {
+      output[key] = overrides[key];
+    } else {
+      output[key] = original[key];
+    }
+  });
+  return output;
+}

--- a/js/dom.js
+++ b/js/dom.js
@@ -1,28 +1,26 @@
-export default class Dom {
-  static create(name, attributes) {
-    const elem = document.createElement(name);
-    if (attributes.classNames) {
-      elem.setAttribute("class", attributes.classNames.join(" "));
-    }
-    return elem;
+export function create(name, attributes) {
+  const elem = document.createElement(name);
+  if (attributes.classNames) {
+    elem.setAttribute("class", attributes.classNames.join(" "));
   }
+  return elem;
+}
 
-  static add(elem, location, reference) {
-    reference.insertAdjacentElement(location, elem);
+export function add(elem, location, reference) {
+  reference.insertAdjacentElement(location, elem);
+}
+
+export function clear(elem) {
+  while (elem.firstChild) {
+    elem.removeChild(elem.firstChild);
   }
+}
 
-  static clear(elem) {
-    while (elem.firstChild) {
-      elem.removeChild(elem.firstChild);
-    }
-  }
-
-  static setText(elem, text) {
-    const textNode = document.createTextNode(text);
-    if (elem.firstChild) {
-      elem.replaceChild(textNode, elem.firstChild);
-    } else {
-      elem.appendChild(textNode);
-    }
+export function setText(elem, text) {
+  const textNode = document.createTextNode(text);
+  if (elem.firstChild) {
+    elem.replaceChild(textNode, elem.firstChild);
+  } else {
+    elem.appendChild(textNode);
   }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -4,60 +4,24 @@ import init, {
   search,
   get_index_version as getIndexVersion
 } from "../pkg/stork";
-import Dom from "./dom";
+
+import { create, add, clear, setText } from "./dom";
 import WasmQueue from "./wasmqueue";
 
-const Handlebars = require("handlebars");
+import { generateScoresListItem, generateListItem } from "./pencil";
+import { defaultConfig, calculateOverriddenConfig } from "./config";
 
-Handlebars.registerHelper("highlight", (textUnesc, highlight_ranges) => {
-  var text = Handlebars.escapeExpression(textUnesc);
+// const Handlebars = require("handlebars");
 
-  function insert(str, index, value) {
-    return str.substr(0, index) + value + str.substr(index);
-  }
-
-  var charactersAlreadyAdded = 0;
-
-  for (let range of highlight_ranges) {
-    let beginningInsertion = `<span class="stork-highlight">`;
-    text = insert(
-      text,
-      range.beginning + charactersAlreadyAdded,
-      beginningInsertion
-    );
-    charactersAlreadyAdded += beginningInsertion.length;
-
-    let endInsertion = `</span>`;
-    text = insert(text, range.end + charactersAlreadyAdded, endInsertion);
-    charactersAlreadyAdded += endInsertion.length;
-  }
-
-  return new Handlebars.SafeString(text);
-});
+// Handlebars.registerHelper("highlight", (text, ranges) => {
+//   console.log(highlight(Handlebars.escapeExpression(text), ranges));
+//   return Handlebars.SafeString(highlight(text, ranges));
+// });
 
 const prod = process.env.NODE_ENV === "production";
 const wasmUrl = prod
   ? "https://files.stork-search.net/stork.wasm"
   : "http://127.0.0.1:8080/stork.wasm";
-
-const showScoresListItemTemplateString = `
-    <li class="stork-result">
-      <a href="{{entry.url}}">
-          <div style="display: flex; justify-content: space-between">
-            <p class="stork-title">{{entry.title}}</p>
-            <code><b>{{score}}</b></code>
-          </div>
-
-          {{#each excerpts}}
-            <div style="display: flex; justify-content: space-between">
-              <p class="stork-excerpt">
-              ...{{ highlight text highlight_ranges }}...
-              </p>
-              <code>{{score}}</code>
-            </div>
-          {{/each}}
-      </a>
-    </li>`;
 
 const wasmQueue = new WasmQueue();
 const entities = {};
@@ -65,24 +29,6 @@ init(wasmUrl).then(() => {
   wasmQueue.loaded = true;
   wasmQueue.handleWasmLoad();
 });
-
-const defaultConfig = {
-  showProgress: true,
-  printIndexInfo: false,
-  showScores: false,
-
-  listItemTemplateString: `
-    <li class="stork-result">
-      <a href="{{entry.url}}">
-          <p class="stork-title">{{entry.title}}</p>
-          {{#each excerpts}}
-            <p class="stork-excerpt">
-              ...{{ highlight text highlight_ranges }}...
-            </p>
-          {{/each}}
-      </a>
-    </li>`
-};
 
 function updateDom(name) {
   if (!name) {
@@ -93,11 +39,11 @@ function updateDom(name) {
 
   if (entity.config.showProgress && entity.progress < 1) {
     if (!entity.elements.progress) {
-      entity.elements.progress = Dom.create("div", {
+      entity.elements.progress = create("div", {
         classNames: ["stork-loader"]
       });
 
-      Dom.add(entity.elements.progress, "afterend", entity.elements.input);
+      add(entity.elements.progress, "afterend", entity.elements.input);
     }
 
     entity.elements.progress.style.width = `${entity.progress * 100}%`;
@@ -124,27 +70,29 @@ function updateDom(name) {
   }
 
   if (!entity.elements.message) {
-    entity.elements.message = Dom.create("div", {
+    entity.elements.message = create("div", {
       classNames: ["stork-message"]
     });
-    Dom.add(entity.elements.message, "afterBegin", entity.elements.output);
+    add(entity.elements.message, "afterBegin", entity.elements.output);
   }
 
-  Dom.setText(entity.elements.message, message);
+  setText(entity.elements.message, message);
 
   if (entity.results) {
     if (entity.results.length > 0) {
       if (!entity.elements.list) {
-        entity.elements.list = Dom.create("ul", {
+        entity.elements.list = create("ul", {
           classNames: ["stork-results"]
         });
-        Dom.add(entity.elements.list, "beforeEnd", entity.elements.output);
+        add(entity.elements.list, "beforeEnd", entity.elements.output);
       }
 
-      Dom.clear(entity.elements.list);
+      clear(entity.elements.list);
 
       entity.results.forEach(result => {
-        const listItem = entity.config.listItemTemplate(result);
+        const listItem = entity.config.showScores
+          ? generateScoresListItem(result)
+          : generateListItem(result);
         entity.elements.list.insertAdjacentHTML("beforeEnd", listItem);
       });
     } else if (entity.elements.list) {
@@ -156,7 +104,7 @@ function updateDom(name) {
   if (!entity.query || entity.query.length === 0) {
     entity.elements.message = null;
     entity.elements.list = null;
-    Dom.clear(entity.elements.output);
+    clear(entity.elements.output);
     entity.elements.output.classList.remove("stork-output-visible");
   } else {
     entity.elements.output.classList.add("stork-output-visible");
@@ -167,7 +115,11 @@ async function resolveSearch(index, query) {
   if (!wasmQueue.loaded) {
     return null;
   }
-  return JSON.parse(search(index, query));
+  try {
+    return JSON.parse(search(index, query));
+  } catch (e) {
+    // analytics.log(e)
+  }
 }
 
 function handleInputEvent(event) {
@@ -196,6 +148,12 @@ function performSearch(name) {
   const { query } = entities[name];
   if (query && query.length >= 3) {
     resolveSearch(entities[name].index, query).then(results => {
+      // Results might be undefined if resolveSearch errored. However, if this
+      // happens, resolveSearch should log the error itself.
+      if (!results) {
+        return;
+      }
+
       if (process.env.NODE_ENV === "development") {
         console.log(results);
       }
@@ -259,36 +217,24 @@ function loadIndexFromUrl(name, url, callbacks) {
   r.send();
 }
 
-function calculateOverriddenConfig(original, overrides) {
-  const output = Object.create({});
-  Object.keys(original).forEach(key => {
-    if (key in overrides) {
-      output[key] = overrides[key];
-    } else {
-      output[key] = original[key];
-    }
-  });
-  return output;
-}
-
 export function register(name, url, config = {}) {
   const configOverride = calculateOverriddenConfig(defaultConfig, config);
 
   // Use the showScores list item template string if the showScores config key
   // is set to true.
-  if (
-    configOverride.showScores &&
-    configOverride.listItemTemplateString ===
-      defaultConfig.listItemTemplateString
-  ) {
-    configOverride.listItemTemplateString = showScoresListItemTemplateString;
-  }
+  // if (
+  //   configOverride.showScores &&
+  //   configOverride.listItemTemplateString ===
+  //     defaultConfig.listItemTemplateString
+  // ) {
+  //   configOverride.listItemTemplateString = showScoresListItemTemplateString;
+  // }
 
   entities[name] = { config: configOverride, elements: {} };
-  entities[name].config.listItemTemplate = Handlebars.compile(
-    entities[name].config.listItemTemplateString,
-    { strict: true }
-  );
+  // entities[name].config.listItemTemplate = Handlebars.compile(
+  //   entities[name].config.listItemTemplateString,
+  //   { strict: true }
+  // );
 
   loadIndexFromUrl(name, url, {
     load: (event, indexName) => {

--- a/js/index.js
+++ b/js/index.js
@@ -11,13 +11,6 @@ import WasmQueue from "./wasmqueue";
 import { generateScoresListItem, generateListItem } from "./pencil";
 import { defaultConfig, calculateOverriddenConfig } from "./config";
 
-// const Handlebars = require("handlebars");
-
-// Handlebars.registerHelper("highlight", (text, ranges) => {
-//   console.log(highlight(Handlebars.escapeExpression(text), ranges));
-//   return Handlebars.SafeString(highlight(text, ranges));
-// });
-
 const prod = process.env.NODE_ENV === "production";
 const wasmUrl = prod
   ? "https://files.stork-search.net/stork.wasm"
@@ -220,21 +213,7 @@ function loadIndexFromUrl(name, url, callbacks) {
 export function register(name, url, config = {}) {
   const configOverride = calculateOverriddenConfig(defaultConfig, config);
 
-  // Use the showScores list item template string if the showScores config key
-  // is set to true.
-  // if (
-  //   configOverride.showScores &&
-  //   configOverride.listItemTemplateString ===
-  //     defaultConfig.listItemTemplateString
-  // ) {
-  //   configOverride.listItemTemplateString = showScoresListItemTemplateString;
-  // }
-
   entities[name] = { config: configOverride, elements: {} };
-  // entities[name].config.listItemTemplate = Handlebars.compile(
-  //   entities[name].config.listItemTemplateString,
-  //   { strict: true }
-  // );
 
   loadIndexFromUrl(name, url, {
     load: (event, indexName) => {

--- a/js/pencil.js
+++ b/js/pencil.js
@@ -1,0 +1,64 @@
+// It's like Handlebars, but smaller.
+
+function highlight(text, highlight_ranges) {
+  function insert(str, index, value) {
+    return str.substr(0, index) + value + str.substr(index);
+  }
+
+  var charactersAlreadyAdded = 0;
+
+  for (let range of highlight_ranges) {
+    let beginningInsertion = `<span class="stork-highlight">`;
+    let endInsertion = `</span>`;
+
+    text = insert(
+      text,
+      range.beginning + charactersAlreadyAdded,
+      beginningInsertion
+    );
+    charactersAlreadyAdded += beginningInsertion.length;
+
+    text = insert(text, range.end + charactersAlreadyAdded, endInsertion);
+    charactersAlreadyAdded += endInsertion.length;
+  }
+
+  return text;
+}
+
+export function generateListItem(r) {
+  return `
+<li class="stork-result">
+    <a href="${r.entry.url}">
+        <p class="stork-title">${r.entry.title}</p>
+        ${r.excerpts
+          .map(
+            e => `<p class="stork-excerpt">
+          ...${highlight(e.text, e.highlight_ranges)}...
+          </p>`
+          )
+          .join("")}
+    </a>
+</li>`;
+}
+
+export function generateScoresListItem(r) {
+  return `
+<li class="stork-result">
+    <a href="${r.entry.url}">
+      <div style="display: flex; justify-content: space-between">
+        <p class="stork-title">${r.entry.title}</p>
+        <code><b>${r.score}</b></code>
+      </div>
+        ${r.excerpts
+          .map(
+            e => `<div style="display: flex; justify-content: space-between">
+              <p class="stork-excerpt">
+                ...${highlight(e.text, e.highlight_ranges)}...
+              </p>
+              <code>${e.score}</code>
+            </div>`
+          )
+          .join("")}
+    </a>
+</li>`;
+}

--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
     "webpack": "^4.41.4",
     "webpack-cli": "^3.3.10"
   },
-  "dependencies": {
-    "handlebars": "^4.5.3"
-  },
+  "dependencies": {},
   "scripts": {
     "build:wasm": "wasm-pack build --target web",
     "build:test-index": "cargo run -- --build test/federalist.toml && mkdir -p dist && cp test/federalist.st dist",

--- a/src/index_versions/v2/builder.rs
+++ b/src/index_versions/v2/builder.rs
@@ -9,6 +9,9 @@ use std::path::Path;
 extern crate rust_stemmers;
 use rust_stemmers::{Algorithm, Stemmer};
 
+extern crate htmlescape;
+use htmlescape::encode_minimal;
+
 pub fn build(config: &Config) -> Index {
     let en_stemmer = Stemmer::create(Algorithm::English);
     let mut entries: Vec<Entry> = Vec::new();
@@ -25,6 +28,7 @@ pub fn build(config: &Config) -> Index {
         let mut contents = String::new();
         let _bytes_read = buf_reader.read_to_string(&mut contents);
         let stork_fields = stork_file.fields.clone();
+        contents = encode_minimal(&contents);
 
         let entry = Entry {
             contents,

--- a/src/index_versions/v2/scores.rs
+++ b/src/index_versions/v2/scores.rs
@@ -1,4 +1,4 @@
 pub const MATCHED_WORD_SCORE: u8 = 128;
 pub const PREFIX_SCORE: u8 = 127;
 pub const STEM_SCORE: u8 = 64;
-pub const STOPWORD_SCORE: u8 = 32;
+pub const STOPWORD_SCORE: u8 = 16;

--- a/src/index_versions/v2/search.rs
+++ b/src/index_versions/v2/search.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 
 const EXCERPT_BUFFER: usize = 8;
-const EXCERPTS_PER_RESULT: usize = 10;
+const EXCERPTS_PER_RESULT: usize = 5;
 const DISPLAYED_RESULTS_COUNT: usize = 10;
 
 #[derive(Clone, Debug, Eq)]
@@ -225,10 +225,10 @@ pub fn search(index: &IndexFromFile, query: &str) -> SearchOutput {
         .take(DISPLAYED_RESULTS_COUNT)
         .collect();
     output_results.sort_by_key(|or| -(or.score as i64));
-    let or_len = &output_results.len();
+    let total_len = &excerpts_by_index.len();
 
     SearchOutput {
         results: output_results,
-        total_hit_count: *or_len,
+        total_hit_count: *total_len,
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,7 +800,7 @@ command-exists@^1.2.7:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
-commander@^2.20.0, commander@~2.20.3:
+commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -1790,17 +1790,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
-handlebars@^4.5.3:
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.3.tgz#8ece2797826886cf8082d1726ff21d2a022550ee"
-  integrity sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==
-  dependencies:
-    neo-async "^2.6.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -2614,7 +2603,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
+neo-async@^2.5.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
@@ -2774,7 +2763,7 @@ opener@^1.5.1:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
   integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
-optimist@^0.6.1, optimist@~0.6.1:
+optimist@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
@@ -3851,14 +3840,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-uglify-js@^3.1.4:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.8.0.tgz#f3541ae97b2f048d7e7e3aa4f39fd8a1f5d7a805"
-  integrity sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==
-  dependencies:
-    commander "~2.20.3"
-    source-map "~0.6.1"
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Handlebars is far too big a dependency for the limited functionality I'm getting from it. Let's just use template strings instead.

This does mean that the `listItemTemplateString` config key is no more, and that people (for now) can't customize the elements being added to the DOM. This would technically be a breaking change if anyone were using Stork.

I think we'll need to make sure that the content is being appropriately escaped; in other words, I think this is vulnerable as-is if the index content contains malicious content.