### PR TITLE
Lift per_file_input_config outside of loop to avoid a potentially expensive clone

### DIFF
--- a/src/index_versions/v3/builder/fill_intermediate_entries.rs
+++ b/src/index_versions/v3/builder/fill_intermediate_entries.rs
@@ -16,6 +16,9 @@ pub fn fill_intermediate_entries(
     }
 
     let base_directory = Path::new(&config.input.base_directory);
+
+    let mut per_file_input_config = config.input.clone();
+
     for stork_file in config.input.files.iter() {
         let filetype = &stork_file.computed_filetype().unwrap_or_else(|| panic!("Cannot determine a filetype for {}. Please include a filetype field in your config file or use a known file extension.", &stork_file.title));
 
@@ -44,7 +47,6 @@ pub fn fill_intermediate_entries(
             StemmingConfig::None => None,
         };
 
-        let mut per_file_input_config = config.input.clone();
         per_file_input_config.html_selector = stork_file.html_selector_override.clone();
         per_file_input_config.frontmatter_handling = stork_file
             .frontmatter_handling_override


### PR DESCRIPTION
My input config had 118,000 file object - each with DataSource::Contents - so we were spending tons (n * n) of time cloning here when it's not necessary

By hoisting the clone out of the loop and mutating thereafter, we avoid the expensive cloning.

This reduced my index build time from just under 3 hours to 55 seconds