### PR TITLE
Index small substrings if they seem ideographic

### DIFF
--- a/js/entity.ts
+++ b/js/entity.ts
@@ -3,6 +3,8 @@ import { Result, SearchData, resolveSearch } from "./searchData";
 import WasmQueue from "./wasmQueue";
 import { EntityDom, RenderState } from "./entityDom";
 
+const minimumQueryLength = 1;
+
 export class Entity {
   readonly name: string;
   readonly url: string;
@@ -40,7 +42,7 @@ export class Entity {
       return "Error! Check the browser console.";
     } else if (this.progress < 1 || !this.wasmQueue.loaded) {
       return "Loading...";
-    } else if (query?.length < 3) {
+    } else if (query?.length < minimumQueryLength) {
       return "Filtering...";
     } else if (this.results) {
       if (this.totalResultCount === 0) {
@@ -131,7 +133,7 @@ export class Entity {
       return;
     }
 
-    if (query.length >= 3) {
+    if (query.length >= minimumQueryLength) {
       resolveSearch(this.index, query)
         .then((data: SearchData) => {
           if (!data) return;

--- a/src/index_versions/v3/builder/fill_containers.rs
+++ b/src/index_versions/v3/builder/fill_containers.rs
@@ -92,8 +92,12 @@ fn fill_other_containers_alias_maps_with_prefixes(
     normalized_word: &str,
 ) {
     let chars: Vec<char> = normalized_word.chars().collect();
-    for n in 3..chars.len() {
+    for n in 1..chars.len() {
         let substring: String = chars[0..n].iter().collect();
+
+        if n < 3 && !string_is_cjk_ideographic(&substring) {
+            continue;
+        }
 
         let alises_map = &mut containers
             .entry(substring.clone())
@@ -128,5 +132,47 @@ fn fill_other_containers_alias_maps_with_reverse_stems(
                 }
             }
         }
+    }
+}
+
+fn string_is_cjk_ideographic(s: &str) -> bool {
+    s.chars()
+        .map(char_is_cjk_ideograph)
+        .fold(true, |acc, x| acc & x)
+}
+
+
+fn char_is_cjk_ideograph(c: char) -> bool {
+    // Block ranges sourced from https://en.wikipedia.org/wiki/CJK_Unified_Ideographs#CJK_Unified_Ideographs_blocks
+    match c {
+        // CJK Unified Ideographs
+        '\u{4E00}'..='\u{62FF}' |
+        '\u{6300}'..='\u{77FF}' |
+        '\u{7800}'..='\u{8CFF}' |
+        '\u{8D00}'..='\u{9FFF}' |
+        // CJK Unified Ideographs Extension A
+        '\u{3400}'..='\u{4DBF}' |
+        // CJK Unified Ideographs Extension B
+        '\u{20000}'..='\u{215FF}' |
+        '\u{21600}'..='\u{230FF}' |
+        '\u{23100}'..='\u{245FF}' |
+        '\u{24600}'..='\u{260FF}' |
+        '\u{26100}'..='\u{275FF}' |
+        '\u{27600}'..='\u{290FF}' |
+        '\u{29100}'..='\u{2A6DF}' |
+        // CJK Unified Ideographs Extension C
+        '\u{2A700}'..='\u{2B73F}' |
+        // CJK Unified Ideographs Extension D
+        '\u{2B740}'..='\u{2B81F}' |
+        // CJK Unified Ideographs Extension E
+        '\u{2B820}'..='\u{2CEAF}' |
+        // CJK Unified Ideographs Extension F
+        '\u{2CEB0}'..='\u{2EBEF}' |
+        // CJK Unified Ideographs Extension G
+        '\u{30000}'..='\u{3134F}' |
+        // CJK Compatibility Ideographs
+        '\u{F900}'..='\u{FAFF}'
+        => true,
+        _ => false,
     }
 }


### PR DESCRIPTION
The motivation is laid out in #73.

To recap: Chinese sentences are composed of characters with no whitespace delimination between words. Individual "words" are composed of 1 or more characters. So, in order to produce useful search results for a corpus with Chinese sentences, we'd like to index at a more granular level than clusters of three characters.

For indexing, the approach implemented by this commit is to examine 1 and 2 length substrings and to index them if they appear to be Chinese. We do this by checking to see if the substring is composed of CJK Ideographic characters (https://en.wikipedia.org/wiki/CJK_Unified_Ideographs), which also covers Japanese and Korean ideographs.

On the UI side, we run into the issue of searches not being accepted unless there are 3 characters. I lowered the minimum query length to 1. This is because I didn't have any performance issues with small searches after my next PR (incoming.) I'm definitely not sure if you'd like to go with this approach, as it will cause more searches to be triggered that might not be fruitful. Alternatively, we could use the same CJK check on the search input, and only search on small strings if it meets that criteria

(I'm not personally using the Stork javascript frontend at this point in time, so it's still useful for me without the frontend change, but maybe not useful to others)