### PR TITLE
Split decoding and searching into two API calls to improve performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
+name = "js-sys"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,8 +1039,10 @@ dependencies = [
  "futures",
  "htmlescape",
  "hyper",
+ "js-sys",
  "markdown",
  "num-format",
+ "once_cell",
  "rmp-serde",
  "rust-stemmers",
  "scraper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ futures = {version = "0.3", optional = true}
 hyper = {version = "0.13", optional = true}
 tokio = { version = "0.2", features = ["full"], optional = true }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+once_cell = "1"
+js-sys = "0.3"
 
 # wasm-opt is out of date in wasm-bindgen, so we have to manually
 # enable the "mutable globals" feature so wasm-opt doesn't reject

--- a/js/entity.ts
+++ b/js/entity.ts
@@ -1,5 +1,5 @@
 import { Configuration } from "./config";
-import { Result, SearchData, resolveSearch } from "./searchData";
+import { Result, SearchData, resolveSearch, parseIndex } from "./searchData";
 import WasmQueue from "./wasmQueue";
 import { EntityDom, RenderState } from "./entityDom";
 
@@ -11,6 +11,7 @@ export class Entity {
   readonly domManager: EntityDom;
 
   index: Uint8Array;
+  indexToken: number | null = null;
   results: Array<Result> = [];
   highlightedResult = 0;
   progress = 0;
@@ -131,8 +132,12 @@ export class Entity {
       return;
     }
 
+    if (this.indexToken == null) {
+      this.indexToken = parseIndex(this.index);
+    }
+
     if (query.length >= 3) {
-      resolveSearch(this.index, query)
+      resolveSearch(this.indexToken, query)
         .then((data: SearchData) => {
           if (!data) return;
 

--- a/js/searchData.ts
+++ b/js/searchData.ts
@@ -1,4 +1,4 @@
-import { wasm_search } from "stork-search";
+import { wasm_search, wasm_parse_index } from "stork-search";
 
 export interface HighlightRange {
   beginning: number;
@@ -32,15 +32,22 @@ export interface SearchData {
   url_prefix: string;
 }
 
-export async function resolveSearch(
+export function parseIndex(
   index: Uint8Array,
+): number {
+  if (index.length === 0) {
+    throw Error("Tried to parse an empty index.");
+  }
+
+  return wasm_parse_index(index);
+}
+
+export async function resolveSearch(
+  index: number,
   query: string
 ): Promise<SearchData> {
   let searchOutput = null;
   let data = null;
-  if (index.length === 0) {
-    throw Error("Tried to search with an empty index.");
-  }
 
   try {
     searchOutput = wasm_search(index, query);
@@ -64,7 +71,7 @@ export async function resolveSearch(
     throw Error(`Could not perform search: the WASM binary failed to return search results.
     You might not be serving your search index properly.
     If you think this is an error, please file a bug: https://jil.im/storkbug
-    
+
     The WASM binary came back with:
     ${data.error}`);
   }

--- a/src/bin/stork/main.rs
+++ b/src/bin/stork/main.rs
@@ -32,7 +32,7 @@ Impossibly fast web search, made for static sites.
 USAGE:
     stork --build [config.toml]
 
-        Builds a search index from the specifications in the TOML configuration 
+        Builds a search index from the specifications in the TOML configuration
         file. See https://stork-search.net/docs/build for more information.
 
     stork --test [config.toml]
@@ -41,7 +41,7 @@ USAGE:
         webpage on http://127.0.0.1:1612 that shows a search bar using that index.
 
     stork --search [./index.st] "[query]"
-    
+
         Given a search index file, searches for the given query and outputs
         the results in JSON.
 "#,
@@ -119,7 +119,14 @@ fn search_handler(args: &[String]) {
     let mut index_bytes: Vec<u8> = Vec::new();
     let bytes_read = buf_reader.read_to_end(&mut index_bytes);
     let read_time = Instant::now();
-    let results = stork::search(&index_bytes, args[3].clone());
+    let index = match stork::parse_index(&index_bytes) {
+        Ok(index) => index,
+        Err(e) => {
+            eprintln!("Error parsing index: {}", e);
+            std::process::exit(EXIT_FAILURE);
+        }
+    };
+    let results = stork::search(&index, &args[3]);
     let end_time = Instant::now();
 
     match results {

--- a/src/index_versions/mod.rs
+++ b/src/index_versions/mod.rs
@@ -1,3 +1,67 @@
 // pub mod v1; // RIP
 pub mod v2;
 pub mod v3;
+
+use crate::searcher::index_analyzer::VersionParseError;
+use crate::common::IndexFromFile;
+use wasm_bindgen::JsValue;
+
+pub enum ParsedIndex {
+   V2(v2::structs::Index),
+   V3(v3::structs::Index),
+}
+
+#[derive(Debug)]
+pub enum IndexParseError {
+   VersionParseError(VersionParseError),
+   DecodeError(rmp_serde::decode::Error),
+}
+
+impl From<VersionParseError> for IndexParseError {
+   fn from(e: VersionParseError) -> IndexParseError {
+      IndexParseError::VersionParseError(e)
+   }
+}
+
+impl From<rmp_serde::decode::Error> for IndexParseError {
+   fn from(e: rmp_serde::decode::Error) -> IndexParseError {
+      IndexParseError::DecodeError(e)
+   }
+}
+
+impl std::fmt::Display for IndexParseError {
+   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+      match self {
+         IndexParseError::DecodeError(e) => write!(f, "Error decoding index: {}", e),
+         IndexParseError::VersionParseError(e) => write!(f, "Error parsing index version: {}", e),
+      }
+  }
+}
+
+impl Into<JsValue> for IndexParseError {
+   fn into(self) -> JsValue {
+      js_sys::Error::new(&self.to_string()).into()
+  }
+}
+
+impl std::convert::TryFrom<&IndexFromFile> for ParsedIndex {
+   type Error = IndexParseError;
+
+   fn try_from(index: &IndexFromFile) -> Result<ParsedIndex, IndexParseError> {
+      use crate::index_versions;
+      use crate::searcher::index_analyzer::{parse_index_version, IndexVersion};
+
+      let parsed_index = match parse_index_version(index)? {
+          IndexVersion::V2 => {
+              let index = index_versions::v2::structs::Index::from_file(index);
+              ParsedIndex::V2(index)
+          }
+          IndexVersion::V3 => {
+              let index = index_versions::v3::structs::Index::try_from(index)?;
+              ParsedIndex::V3(index)
+          }
+      };
+
+      Ok(parsed_index)
+   }
+}

--- a/src/index_versions/v2/search.rs
+++ b/src/index_versions/v2/search.rs
@@ -1,6 +1,6 @@
 use super::scores::*;
 use super::structs::*;
-use crate::common::{IndexFromFile, STOPWORDS};
+use crate::common::STOPWORDS;
 use crate::searcher::*;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -209,13 +209,12 @@ impl From<EntryAndIntermediateExcerpts> for OutputResult {
     }
 }
 
-pub fn search(index: &IndexFromFile, query: &str) -> Result<SearchOutput, SearchError> {
+pub fn search(index: &Index, query: &str) -> Result<SearchOutput, SearchError> {
     std::panic::catch_unwind(|| internal_search(index, query))
         .map_err(|_e| SearchError::InternalCrash)
 }
 
-pub fn internal_search(index: &IndexFromFile, query: &str) -> SearchOutput {
-    let index = Index::from_file(index);
+pub fn internal_search(index: &Index, query: &str) -> SearchOutput {
     let normalized_query = query.to_lowercase();
     let words_in_query: Vec<String> = normalized_query.split(' ').map(|s| s.to_string()).collect();
 
@@ -278,7 +277,8 @@ mod tests {
         let mut index_bytes: Vec<u8> = Vec::new();
         let _bytes_read = buf_reader.read_to_end(&mut index_bytes);
 
-        let generated = search(index_bytes.as_slice(), "liber old world").unwrap();
+        let index = Index::from_file(index_bytes.as_slice());
+        let generated = search(&index, "liber old world").unwrap();
         let expected = serde_json::from_str("{\"results\":[{\"entry\":{\"url\":\"https://www.congress.gov/resources/display/content/The+Federalist+Papers#TheFederalistPapers-1\",\"title\":\"Introduction\",\"fields\":{}},\"excerpts\":[{\"text\":\"in many respects the most interesting in the world. It has been frequently remarked that it\",\"highlight_ranges\":[{\"beginning\":45,\"end\":50}],\"score\":128,\"internal_annotations\":[],\"fields\":{}},{\"text\":\"despotic power and hostile to the principles of liberty. An over-scrupulous jealousy of danger to the\",\"highlight_ranges\":[{\"beginning\":48,\"end\":55}],\"score\":125,\"internal_annotations\":[],\"fields\":{}},{\"text\":\"of love, and that the noble enthusiasm of liberty is apt to be infected with a\",\"highlight_ranges\":[{\"beginning\":42,\"end\":49}],\"score\":125,\"internal_annotations\":[],\"fields\":{}},{\"text\":\"of government is essential to the security of liberty; that, in the contemplation of a sound\",\"highlight_ranges\":[{\"beginning\":46,\"end\":53}],\"score\":125,\"internal_annotations\":[],\"fields\":{}},{\"text\":\"that this is the safest course for your liberty, your dignity, and your happiness. I affect\",\"highlight_ranges\":[{\"beginning\":40,\"end\":47}],\"score\":125,\"internal_annotations\":[],\"fields\":{}}],\"title_highlight_ranges\":[],\"score\":128}],\"total_hit_count\":1,\"url_prefix\":\"\"}").unwrap();
 
         assert_eq!(

--- a/src/index_versions/v3/search/mod.rs
+++ b/src/index_versions/v3/search/mod.rs
@@ -1,70 +1,64 @@
 use super::scores::*;
 use super::structs::*;
-use crate::common::{IndexFromFile, STOPWORDS};
+use crate::common::STOPWORDS;
 use crate::config::TitleBoost;
 use crate::searcher::*;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 
 pub mod intermediate_excerpt;
 use intermediate_excerpt::IntermediateExcerpt;
 
-pub fn search(index: &IndexFromFile, query: &str) -> Result<SearchOutput, SearchError> {
-    match Index::try_from(index) {
-        Err(_e) => Err(SearchError::IndexParseError),
-        Ok(index) => {
-            let normalized_query = query.to_lowercase();
-            let words_in_query: Vec<String> =
-                normalized_query.split(' ').map(|s| s.to_string()).collect();
+pub fn search(index: &Index, query: &str) -> SearchOutput {
+    let normalized_query = query.to_lowercase();
+    let words_in_query: Vec<String> =
+        normalized_query.split(' ').map(|s| s.to_string()).collect();
 
-            // Get the containers for each word in the query, and separate them
-            // into intermediate excerpts
-            let mut intermediate_excerpts: Vec<IntermediateExcerpt> = words_in_query
-                .iter()
-                .flat_map(|word| index.containers.get_key_value(word))
-                .map(|(word, ctr)| ContainerWithQuery::new(ctr.to_owned(), word))
-                .map(|ctr_query| ctr_query.get_intermediate_excerpts(&index))
-                .flatten()
-                .collect();
+    // Get the containers for each word in the query, and separate them
+    // into intermediate excerpts
+    let mut intermediate_excerpts: Vec<IntermediateExcerpt> = words_in_query
+        .iter()
+        .flat_map(|word| index.containers.get_key_value(word))
+        .map(|(word, ctr)| ContainerWithQuery::new(ctr.to_owned(), word))
+        .map(|ctr_query| ctr_query.get_intermediate_excerpts(&index))
+        .flatten()
+        .collect();
 
-            for mut ie in &mut intermediate_excerpts {
-                if STOPWORDS.contains(&ie.query.as_str()) {
-                    ie.score = STOPWORD_SCORE;
-                }
-            }
-
-            let mut excerpts_by_index: HashMap<EntryIndex, Vec<IntermediateExcerpt>> =
-                HashMap::new();
-            for ie in intermediate_excerpts {
-                excerpts_by_index
-                    .entry(ie.entry_index)
-                    .or_insert_with(Vec::new)
-                    .push(ie)
-            }
-
-            let total_len = &excerpts_by_index.len();
-
-            let mut output_results: Vec<OutputResult> = excerpts_by_index
-                .iter()
-                .map(|(entry_index, ies)| {
-                    let data = EntryAndIntermediateExcerpts {
-                        entry: index.entries[*entry_index].to_owned(),
-                        config: index.config.clone(),
-                        intermediate_excerpts: ies.to_owned(),
-                    };
-                    OutputResult::from(data)
-                })
-                .collect();
-            output_results.sort_by_key(|or| or.entry.title.clone());
-            output_results.sort_by_key(|or| -(or.score as i64));
-            output_results.truncate(index.config.displayed_results_count as usize);
-
-            Ok(SearchOutput {
-                results: output_results,
-                total_hit_count: *total_len,
-                url_prefix: index.config.url_prefix,
-            })
+    for mut ie in &mut intermediate_excerpts {
+        if STOPWORDS.contains(&ie.query.as_str()) {
+            ie.score = STOPWORD_SCORE;
         }
+    }
+
+    let mut excerpts_by_index: HashMap<EntryIndex, Vec<IntermediateExcerpt>> =
+        HashMap::new();
+    for ie in intermediate_excerpts {
+        excerpts_by_index
+            .entry(ie.entry_index)
+            .or_insert_with(Vec::new)
+            .push(ie)
+    }
+
+    let total_len = &excerpts_by_index.len();
+
+    let mut output_results: Vec<OutputResult> = excerpts_by_index
+        .iter()
+        .map(|(entry_index, ies)| {
+            let data = EntryAndIntermediateExcerpts {
+                entry: index.entries[*entry_index].to_owned(),
+                config: index.config.clone(),
+                intermediate_excerpts: ies.to_owned(),
+            };
+            OutputResult::from(data)
+        })
+        .collect();
+    output_results.sort_by_key(|or| or.entry.title.clone());
+    output_results.sort_by_key(|or| -(or.score as i64));
+    output_results.truncate(index.config.displayed_results_count as usize);
+
+    SearchOutput {
+        results: output_results,
+        total_hit_count: *total_len,
+        url_prefix: index.config.url_prefix.clone(),
     }
 }
 
@@ -303,6 +297,7 @@ impl From<EntryAndIntermediateExcerpts> for OutputResult {
 mod tests {
     use super::*;
     use std::fs;
+    use std::convert::TryFrom;
     use std::io::{BufReader, Read};
     #[test]
     fn e2e_v3_search_works() {
@@ -311,7 +306,8 @@ mod tests {
         let mut index_bytes: Vec<u8> = Vec::new();
         let _bytes_read = buf_reader.read_to_end(&mut index_bytes);
 
-        let generated = search(index_bytes.as_slice(), "liber old world").unwrap();
+        let index = Index::try_from(index_bytes.as_slice()).unwrap();
+        let generated = search(&index, "liber old world");
         let expected = serde_json::from_str("{\"results\":[{\"entry\":{\"url\":\"https://www.congress.gov/resources/display/content/The+Federalist+Papers#TheFederalistPapers-1\",\"title\":\"Introduction\",\"fields\":{}},\"excerpts\":[{\"text\":\"in many respects the most interesting in the world. It has been frequently remarked that it\",\"highlight_ranges\":[{\"beginning\":45,\"end\":50}],\"score\":128,\"internal_annotations\":[],\"fields\":{}},{\"text\":\"despotic power and hostile to the principles of liberty. An over-scrupulous jealousy of danger to the\",\"highlight_ranges\":[{\"beginning\":48,\"end\":55}],\"score\":125,\"internal_annotations\":[],\"fields\":{}},{\"text\":\"of love, and that the noble enthusiasm of liberty is apt to be infected with a\",\"highlight_ranges\":[{\"beginning\":42,\"end\":49}],\"score\":125,\"internal_annotations\":[],\"fields\":{}},{\"text\":\"of government is essential to the security of liberty; that, in the contemplation of a sound\",\"highlight_ranges\":[{\"beginning\":46,\"end\":53}],\"score\":125,\"internal_annotations\":[],\"fields\":{}},{\"text\":\"that this is the safest course for your liberty, your dignity, and your happiness. I affect\",\"highlight_ranges\":[{\"beginning\":40,\"end\":47}],\"score\":125,\"internal_annotations\":[],\"fields\":{}}],\"title_highlight_ranges\":[],\"score\":128}],\"total_hit_count\":1,\"url_prefix\":\"\"}").unwrap();
 
         assert_eq!(generated, expected, "{:?}", generated);


### PR DESCRIPTION
In my experience with a large search index, decoding the search index on each call made up the vast majority of each search runtime. In order to resolve this, this PR changes the API.

Old process:
1) Run search with query and index bytes

New process:
1) Decode search with index bytes, receive ParsedIndex or index token (WASM) back
2) Run search with query and ParsedIndex / index token

This is a breaking API change.

I don't have any benchmark numbers, but the performance difference can be observed here:
WITHOUT PR: https://www.brick.codes/cedict/stork_old/
WITH PR: https://www.brick.codes/cedict/stork/

There are a couple of definite TODOs remaining:

- [ ] Re-enable and fix two disabled tests
- [ ] Fix error handling when an invalid token is passed (WASM, requires JSON response structure)
- [ ] Ensure documentation is consistent for new API flow

I'm happy to complete them, but I wanted to get this PR out now to get thoughts on it, and allow you to consider this potential API change before 1.0.0.