### PR TITLE
Copy *.st instead of specific index files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,12 +32,7 @@ module.exports = {
           flatten: true
         },
         {
-          from: path.resolve(__dirname, "test", "3b1b.st"),
-          to: ".",
-          flatten: true
-        },
-        {
-          from: path.resolve(__dirname, "test", "federalist.st"),
+          from: path.resolve(__dirname, "test", "*.st"),
           to: ".",
           flatten: true
         }


### PR DESCRIPTION
This prevents Webpack from erroring if one of the test index files can’t be found, which is nice since they’re all technically optional