### PR TITLE
Collect and display indexing errors instead of failing early

### DIFF
--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,6 +1,6 @@
 use super::{FrontmatterConfig, StemmingConfig};
-use serde::{Deserialize, Serialize};
 use core::fmt;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,5 +1,6 @@
 use super::{FrontmatterConfig, StemmingConfig};
 use serde::{Deserialize, Serialize};
+use core::fmt;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -51,6 +52,19 @@ impl File {
         } else {
             None
         }
+    }
+}
+impl fmt::Display for File {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match &self.source {
+                DataSource::FilePath(path) => path,
+                DataSource::Contents(_contents) => &self.title,
+                DataSource::URL(url) => url,
+            }
+        )
     }
 }
 

--- a/src/index_versions/v3/builder/mod.rs
+++ b/src/index_versions/v3/builder/mod.rs
@@ -1,5 +1,5 @@
 use super::structs::*;
-use crate::config::Config;
+use crate::config::{Config, File};
 use std::fmt;
 use std::{collections::HashMap, error::Error, path::PathBuf};
 
@@ -50,11 +50,41 @@ impl fmt::Display for IndexGenerationError {
     }
 }
 
-pub fn build(config: &Config) -> Result<Index, IndexGenerationError> {
+pub struct DocumentError {
+    file: File,
+    word_list_generation_error: WordListGenerationError,
+}
+
+impl fmt::Display for DocumentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Error indexing `{}`: {}",
+            self.file, self.word_list_generation_error
+        )
+    }
+}
+
+pub fn build(config: &Config) -> Result<(Index, Vec<DocumentError>), IndexGenerationError> {
     println!("{}", Nudger::from(config).generate_formatted_output());
 
     let mut intermediate_entries: Vec<IntermediateEntry> = Vec::new();
-    fill_intermediate_entries(&config, &mut intermediate_entries)?;
+    let mut document_errors: Vec<DocumentError> = Vec::new();
+    fill_intermediate_entries(&config, &mut intermediate_entries, &mut document_errors)?;
+
+    if !document_errors.is_empty() {
+        println!(
+            "{} error{} while indexing files:",
+            document_errors.len(),
+            match document_errors.len() {
+                1 => "",
+                _ => "s",
+            }
+        )
+    }
+    for error in &document_errors {
+        println!("- {}", &error);
+    }
 
     let mut stems: HashMap<String, Vec<String>> = HashMap::new();
     fill_stems(&intermediate_entries, &mut stems);
@@ -72,11 +102,14 @@ pub fn build(config: &Config) -> Result<Index, IndexGenerationError> {
         displayed_results_count: config.output.displayed_results_count,
     };
 
-    Ok(Index {
-        entries,
-        containers,
-        config,
-    })
+    Ok((
+        Index {
+            entries,
+            containers,
+            config,
+        },
+        document_errors,
+    ))
 }
 
 fn remove_surrounding_punctuation(input: &str) -> String {
@@ -98,6 +131,7 @@ mod tests {
     use super::*;
     use crate::config::File;
     use crate::config::*;
+
     #[test]
     fn test_not_present_html_selector_fails_gracefully() {
         let config = Config {
@@ -114,6 +148,39 @@ mod tests {
             ..Default::default()
         };
 
-        build(&config).expect_err("Config didn't error when it should have!");
+        assert_eq!(build(&config).unwrap().1.len(), 1);
+
+        assert_eq!(
+            build(&config).unwrap().1.first().unwrap().to_string(),
+            "Error indexing `Title`: HTML selector `.article` is not present in the file."
+        );
+    }
+
+    #[test]
+    fn test_failing_file_does_not_halt_indexing() {
+        let config = Config {
+            input: InputConfig {
+                files: vec![
+                    File {
+                        source: DataSource::Contents("".to_string()),
+                        title: "Title".to_string(),
+                        filetype: Some(Filetype::HTML),
+                        html_selector_override: Some(".article".to_string()),
+                        ..Default::default()
+                    },
+                    File {
+                        source: DataSource::Contents("".to_string()),
+                        title: "Title 2".to_string(),
+                        filetype: Some(Filetype::PlainText),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(build(&config).unwrap().1.len(), 1);
+        assert_eq!(build(&config).unwrap().0.entries.len(), 1);
     }
 }

--- a/src/index_versions/v3/builder/mod.rs
+++ b/src/index_versions/v3/builder/mod.rs
@@ -27,9 +27,7 @@ extern crate rust_stemmers;
 
 #[derive(Debug)]
 pub enum IndexGenerationError {
-    NoFilesSpecified,
-    FileNotFoundError(PathBuf),
-    WordListGenerationError(WordListGenerationError),
+    NoFilesSpecified
 }
 
 impl Error for IndexGenerationError {}
@@ -40,10 +38,6 @@ impl fmt::Display for IndexGenerationError {
             IndexGenerationError::NoFilesSpecified => {
                 "No files specified in config file".to_string()
             }
-            IndexGenerationError::FileNotFoundError(s) => {
-                format!("File {} not found", s.to_string_lossy())
-            }
-            IndexGenerationError::WordListGenerationError(e) => e.to_string(),
         };
 
         write!(f, "{}", desc)

--- a/src/index_versions/v3/builder/mod.rs
+++ b/src/index_versions/v3/builder/mod.rs
@@ -27,7 +27,7 @@ extern crate rust_stemmers;
 
 #[derive(Debug)]
 pub enum IndexGenerationError {
-    NoFilesSpecified
+    NoFilesSpecified,
 }
 
 impl Error for IndexGenerationError {}

--- a/src/index_versions/v3/builder/word_list_generators/html_word_list_generator.rs
+++ b/src/index_versions/v3/builder/word_list_generators/html_word_list_generator.rs
@@ -38,7 +38,7 @@ impl WordListGenerator for HTMLWordListGenerator {
         // if the selector _is_ present but there are no words.
         let selector_match_in_document_count = document.select(&selector).count();
         if selector_match_in_document_count == 0 {
-            return Err(WordListGenerationError::SelectorNotPresent);
+            return Err(WordListGenerationError::SelectorNotPresent(selector_string));
         }
 
         let word_list = document

--- a/src/index_versions/v3/builder/word_list_generators/mod.rs
+++ b/src/index_versions/v3/builder/word_list_generators/mod.rs
@@ -9,18 +9,22 @@ use html_word_list_generator::{HTMLWordListGenerator, MarkdownWordListGenerator}
 #[derive(Debug)]
 pub enum WordListGenerationError {
     InvalidSRT,
-    SelectorNotPresent,
+    FileNotFound,
+    CannotDetermineFiletype,
+    SelectorNotPresent(String),
 }
 
 impl fmt::Display for WordListGenerationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let desc: String = match self {
-            WordListGenerationError::InvalidSRT => "SRT file could not be parsed",
-            WordListGenerationError::SelectorNotPresent => {
-                "HTML selector is not present in the document"
-            }
-        }
-        .to_string();
+            WordListGenerationError::InvalidSRT => "SRT file could not be parsed".to_string(),
+            WordListGenerationError::SelectorNotPresent(selector_string) => format!(
+                "HTML selector `{}` is not present in the file.",
+                selector_string
+            ),
+            WordListGenerationError::FileNotFound => "The file could not be found".to_string(),
+            WordListGenerationError::CannotDetermineFiletype => "Could not determine the filetype. Please use a known file extension or disambiguate the filetype within your configuration file.".to_string()
+        };
         write!(f, "{}", desc)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,5 +63,5 @@ pub fn search_with_index(index: &Index, query: &str) -> searcher::SearchOutput {
  * Builds an Index object that can be serialized and parsed later
  */
 pub fn build(config: &Config) -> Result<Index, IndexGenerationError> {
-    builder::build(config)
+    builder::build(config).map(|tuple| tuple.0)
 }


### PR DESCRIPTION
In #105, @fauno points out that a file that cannot be indexed will fail the entire indexing process, and points out an issue with this methodology:

> The issue is that it doesn't tell me which page is missing it. Could it tell the path and maybe even skip the page?

This PR changes the indexing behavior so that if a word list generation error is encountered, the code looping through each file collects that error and associates it with the failing file, then prints out the list of errors during indexing, without failing the entire indexing process:

```
2 errors while indexing files:
- Error indexing `myFile.html`: HTML selector `.article` is not present in the file.
- Error indexing `myOtherFile.txt`: The file could not be found
```

This should clarify what is failing and why.

To fully fix #105, I also need to write better documentation describing how Stork handles HTML files -- that's coming later.