### PR TITLE
Return an index generation error if there are no valid files

### DIFF
--- a/src/index_versions/v3/builder/errors.rs
+++ b/src/index_versions/v3/builder/errors.rs
@@ -2,9 +2,10 @@ use super::word_list_generators::WordListGenerationError;
 use crate::config::File;
 use std::{error::Error, fmt};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum IndexGenerationError {
     NoFilesSpecified,
+    NoValidFiles,
 }
 
 impl Error for IndexGenerationError {}
@@ -15,6 +16,7 @@ impl fmt::Display for IndexGenerationError {
             IndexGenerationError::NoFilesSpecified => {
                 "No files specified in config file".to_string()
             }
+            IndexGenerationError::NoValidFiles => "No files could be indexed".to_string(),
         };
 
         write!(f, "{}", desc)
@@ -30,8 +32,8 @@ impl fmt::Display for DocumentError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Error indexing `{}`: {}",
-            self.file, self.word_list_generation_error
+            "Error: {} while indexing `{}`",
+            self.word_list_generation_error, self.file
         )
     }
 }

--- a/src/index_versions/v3/builder/mod.rs
+++ b/src/index_versions/v3/builder/mod.rs
@@ -131,7 +131,7 @@ mod tests {
 
         assert_eq!(
             build(&config).unwrap().1.first().unwrap().to_string(),
-            "Error indexing `Title`: HTML selector `.article` is not present in the file."
+            "Error: HTML selector `.article` is not present in the file while indexing `Title`"
         );
     }
     #[test]

--- a/src/index_versions/v3/builder/mod.rs
+++ b/src/index_versions/v3/builder/mod.rs
@@ -48,6 +48,10 @@ pub fn build(config: &Config) -> Result<(Index, Vec<DocumentError>), IndexGenera
         println!("- {}", &error);
     }
 
+    if intermediate_entries.is_empty() {
+        return Err(IndexGenerationError::NoValidFiles)
+    }
+
     let mut stems: HashMap<String, Vec<String>> = HashMap::new();
     fill_stems(&intermediate_entries, &mut stems);
 
@@ -94,17 +98,30 @@ mod tests {
     use crate::config::File;
     use crate::config::*;
 
+    fn generate_invalid_file() -> File {
+        File {
+            source: DataSource::Contents("".to_string()),
+            title: "Title".to_string(),
+            filetype: Some(Filetype::HTML),
+            html_selector_override: Some(".article".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn generate_valid_file() -> File {
+        File {
+            source: DataSource::Contents("".to_string()),
+            title: "Title 2".to_string(),
+            filetype: Some(Filetype::PlainText),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn test_not_present_html_selector_fails_gracefully() {
         let config = Config {
             input: InputConfig {
-                files: vec![File {
-                    source: DataSource::Contents("".to_string()),
-                    title: "Title".to_string(),
-                    filetype: Some(Filetype::HTML),
-                    html_selector_override: Some(".article".to_string()),
-                    ..Default::default()
-                }],
+                files: vec![generate_invalid_file(), generate_valid_file()],
                 ..Default::default()
             },
             ..Default::default()
@@ -117,25 +134,26 @@ mod tests {
             "Error indexing `Title`: HTML selector `.article` is not present in the file."
         );
     }
+    #[test]
+    fn test_all_invalid_files_return_error() {
+        let config = Config {
+            input: InputConfig {
+                files: vec![generate_invalid_file(), generate_invalid_file()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(build(&config).err().unwrap(), IndexGenerationError::NoValidFiles);
+    }
 
     #[test]
     fn test_failing_file_does_not_halt_indexing() {
         let config = Config {
             input: InputConfig {
                 files: vec![
-                    File {
-                        source: DataSource::Contents("".to_string()),
-                        title: "Title".to_string(),
-                        filetype: Some(Filetype::HTML),
-                        html_selector_override: Some(".article".to_string()),
-                        ..Default::default()
-                    },
-                    File {
-                        source: DataSource::Contents("".to_string()),
-                        title: "Title 2".to_string(),
-                        filetype: Some(Filetype::PlainText),
-                        ..Default::default()
-                    },
+                    generate_invalid_file(),
+                    generate_valid_file()
                 ],
                 ..Default::default()
             },

--- a/src/index_versions/v3/builder/mod.rs
+++ b/src/index_versions/v3/builder/mod.rs
@@ -49,7 +49,7 @@ pub fn build(config: &Config) -> Result<(Index, Vec<DocumentError>), IndexGenera
     }
 
     if intermediate_entries.is_empty() {
-        return Err(IndexGenerationError::NoValidFiles)
+        return Err(IndexGenerationError::NoValidFiles);
     }
 
     let mut stems: HashMap<String, Vec<String>> = HashMap::new();
@@ -144,17 +144,17 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(build(&config).err().unwrap(), IndexGenerationError::NoValidFiles);
+        assert_eq!(
+            build(&config).err().unwrap(),
+            IndexGenerationError::NoValidFiles
+        );
     }
 
     #[test]
     fn test_failing_file_does_not_halt_indexing() {
         let config = Config {
             input: InputConfig {
-                files: vec![
-                    generate_invalid_file(),
-                    generate_valid_file()
-                ],
+                files: vec![generate_invalid_file(), generate_valid_file()],
                 ..Default::default()
             },
             ..Default::default()

--- a/src/index_versions/v3/builder/word_list_generators/mod.rs
+++ b/src/index_versions/v3/builder/word_list_generators/mod.rs
@@ -22,11 +22,11 @@ impl fmt::Display for WordListGenerationError {
         let desc: String = match self {
             WordListGenerationError::InvalidSRT => "SRT file could not be parsed".to_string(),
             WordListGenerationError::SelectorNotPresent(selector_string) => format!(
-                "HTML selector `{}` is not present in the file.",
+                "HTML selector `{}` is not present in the file",
                 selector_string
             ),
             WordListGenerationError::FileNotFound => "The file could not be found".to_string(),
-            WordListGenerationError::CannotDetermineFiletype => "Could not determine the filetype. Please use a known file extension or disambiguate the filetype within your configuration file.".to_string()
+            WordListGenerationError::CannotDetermineFiletype => "Could not determine the filetype. Please use a known file extension or disambiguate the filetype within your configuration file".to_string()
         };
         write!(f, "{}", desc)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,21 +63,6 @@ pub fn search_with_index(index: &Index, query: &str) -> searcher::SearchOutput {
  * Builds an Index object that can be serialized and parsed later
  */
 pub fn build(config: &Config) -> Result<Index, IndexGenerationError> {
-    let (index, document_errors) = builder::build(config)?;
-
-    if !document_errors.is_empty() {
-        println!(
-            "{} error{} while indexing files:",
-            document_errors.len(),
-            match document_errors.len() {
-                1 => "",
-                _ => "s",
-            }
-        )
-    }
-    for error in &document_errors {
-        println!("- {}", &error);
-    }
-
+    let (index, _) = builder::build(config)?;
     Ok(index)
 }


### PR DESCRIPTION
- Fixes a bug where file parse errors were being printed twice (whoops!)
- Returns an index generation error (and errors out nicely) if none of the files are valid, instead of panicking with a divide-by-zero error