### PR TITLE
Allow user to define custom WASM url in stork.initialize()

### DIFF
--- a/js/entityDom.test.ts
+++ b/js/entityDom.test.ts
@@ -52,7 +52,7 @@ describe("entitydom", () => {
       new WasmQueue()
     );
     entity.attachToDom();
-    entityDom = entity.domManager!;
+    entityDom = <EntityDom>entity.domManager;
   });
 
   test("entityDom successfully constructed", () => {

--- a/js/main.ts
+++ b/js/main.ts
@@ -14,7 +14,7 @@ class StorkError extends Error {
 let wasmQueue: WasmQueue | null = null;
 let entityManager: EntityManager | null = null;
 
-function initialize(wasmOverrideUrl: String | null = null): Promise<void> {
+function initialize(wasmOverrideUrl: string | null = null): Promise<void> {
   return new Promise((res, rej) => {
     if (!wasmQueue) {
       wasmQueue = createWasmQueue(wasmOverrideUrl);

--- a/js/main.ts
+++ b/js/main.ts
@@ -26,7 +26,6 @@ function initialize(wasmOverrideUrl: String | null = null): Promise<void> {
       wasmQueue.runOnWasmLoadFailure(e => {
         rej(e);
       });
-
     } else if (wasmQueue.state === "failed") {
       rej();
     } else {

--- a/js/main.ts
+++ b/js/main.ts
@@ -14,13 +14,21 @@ class StorkError extends Error {
 let wasmQueue: WasmQueue | null = null;
 let entityManager: EntityManager | null = null;
 
-function initialize(): Promise<void> {
-  return new Promise((res, _rej) => {
+function initialize(wasmOverrideUrl: String | null = null): Promise<void> {
+  return new Promise((res, rej) => {
     if (!wasmQueue) {
-      wasmQueue = createWasmQueue();
+      wasmQueue = createWasmQueue(wasmOverrideUrl);
+
       wasmQueue.runAfterWasmLoaded(() => {
         res();
       });
+
+      wasmQueue.runOnWasmLoadFailure(e => {
+        rej(e);
+      });
+
+    } else if (wasmQueue.state === "failed") {
+      rej();
     } else {
       res();
     }

--- a/js/wasmLoader.ts
+++ b/js/wasmLoader.ts
@@ -1,17 +1,22 @@
 import init from "stork-search";
 import WasmQueue from "./wasmQueue";
 
-const prod = process.env.NODE_ENV === "production";
+// const version = process.env.VERSION;
+const version = null;
+const DEFAULT_WASM_URL = version
+  ? `https://files.stork-search.net/stork-${version}.wasm`
+  : `https://files.stork-search.net/stork.wasm`;
 
-const wasmUrl = prod
-  ? "https://files.stork-search.net/stork.wasm"
-  : "http://127.0.0.1:8025/stork.wasm";
-
-export function createWasmQueue(): WasmQueue {
+export function createWasmQueue(wasmOverrideUrl: String | null): WasmQueue {
+  const wasmUrl = wasmOverrideUrl || DEFAULT_WASM_URL;
   const queue = new WasmQueue();
-  init(wasmUrl).then(() => {
-    queue.loaded = true;
-    queue.handleWasmLoad();
-  });
+  init(wasmUrl)
+    .then(() => {
+      queue.loaded = true;
+      queue.handleWasmLoad();
+    })
+    .catch(e => {
+      queue.handleWasmFailure(e);
+    });
   return queue;
 }

--- a/js/wasmLoader.ts
+++ b/js/wasmLoader.ts
@@ -7,7 +7,7 @@ const DEFAULT_WASM_URL = version
   ? `https://files.stork-search.net/stork-${version}.wasm`
   : `https://files.stork-search.net/stork.wasm`;
 
-export function createWasmQueue(wasmOverrideUrl: String | null): WasmQueue {
+export function createWasmQueue(wasmOverrideUrl: string | null): WasmQueue {
   const wasmUrl = wasmOverrideUrl || DEFAULT_WASM_URL;
   const queue = new WasmQueue();
   init(wasmUrl)

--- a/js/wasmQueue.ts
+++ b/js/wasmQueue.ts
@@ -1,7 +1,18 @@
+type WasmQueueState = "queueing" | "loaded" | "failed";
+
 export default class WasmQueue {
+  state: WasmQueueState = "queueing";
   loaded = false;
   queue: { (): void }[] = [];
+  failureMethod: { (e: Error): void };
 
+  /**
+   * Caller should use this to queue up a function to be run only when the 
+   * WASM is loaded. If the WASM is already loaded when this method is called,
+   * the function will run immediately.
+   * 
+   * @param fn Function to be run once WASM is loaded
+   */
   runAfterWasmLoaded(fn: { (): void; (): void }): void {
     if (this.loaded) {
       fn();
@@ -10,11 +21,41 @@ export default class WasmQueue {
     }
   }
 
+  /**
+   * Caller should use this to register a function to be run only when the WASM
+   * fails to load. Unlike the happy-path function, calling this will overwrite
+   * any existing error handler function.
+   *
+   * @param fn The function to be called when the WASM fails to load. The function
+   * should take an optional Error parameter.
+   */
+  runOnWasmLoadFailure(fn: { (e: Error | null): void }) {
+    if (this.state === "failed") {
+      fn(null);
+    } else {
+      this.failureMethod = fn;
+    }
+  }
+
+  /**
+   * WASM loader should use this to signal to the queue that the WASM has been
+   * loaded.
+   */
   handleWasmLoad(): void {
     for (const fn of this.queue) {
       fn();
     }
 
     this.queue = [];
+  }
+
+  /**
+   * WASM loader should use this to signal to the queue that loading the WASM
+   * has failed.
+   * 
+   * @param e The error that was recieved while loading the WASM.
+   */
+  handleWasmFailure(e: Error): void {
+    if (this.failureMethod) this.failureMethod(e);
   }
 }

--- a/js/wasmQueue.ts
+++ b/js/wasmQueue.ts
@@ -7,10 +7,10 @@ export default class WasmQueue {
   failureMethod: { (e: Error): void };
 
   /**
-   * Caller should use this to queue up a function to be run only when the 
+   * Caller should use this to queue up a function to be run only when the
    * WASM is loaded. If the WASM is already loaded when this method is called,
    * the function will run immediately.
-   * 
+   *
    * @param fn Function to be run once WASM is loaded
    */
   runAfterWasmLoaded(fn: { (): void; (): void }): void {
@@ -52,7 +52,7 @@ export default class WasmQueue {
   /**
    * WASM loader should use this to signal to the queue that loading the WASM
    * has failed.
-   * 
+   *
    * @param e The error that was recieved while loading the WASM.
    */
   handleWasmFailure(e: Error): void {

--- a/js/wasmQueue.ts
+++ b/js/wasmQueue.ts
@@ -29,7 +29,7 @@ export default class WasmQueue {
    * @param fn The function to be called when the WASM fails to load. The function
    * should take an optional Error parameter.
    */
-  runOnWasmLoadFailure(fn: { (e: Error | null): void }) {
+  runOnWasmLoadFailure(fn: { (e: Error | null): void }): void {
     if (this.state === "failed") {
       fn(null);
     } else {

--- a/test/static/index.html
+++ b/test/static/index.html
@@ -100,7 +100,9 @@
 
     <script src="/stork.js"></script>
     <script>
-      stork.initialize(); // download WASM
+      stork.initialize("http://127.0.0.1:8025/stork.wasm").catch(e => {
+        alert(e);
+      }); // download WASM
 
       stork.downloadIndex("federalist", "/federalist.st", {
         showProgress: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const { version } = require("./package.json");
+const { DefinePlugin } = require("webpack");
 
 const dist = path.resolve(__dirname, "dist");
 
@@ -18,6 +20,9 @@ module.exports = {
   },
   devtool: "inline-source-map",
   plugins: [
+    new DefinePlugin({
+      "process.env.VERSION": JSON.stringify(version)
+    }),
     new CleanWebpackPlugin(),
     new CopyPlugin(
       [


### PR DESCRIPTION
Allow users to define a custom WASM URL.

This will add a "use at your own risk" kind of situation, since I won't be able to verify that the WASM loaded is the right WASM built to work with that version of the Javascript. However, this is required to implement self-hosting Stork, so the benefits outweigh the costs here. I'll add documentation to make it clear that you're taking your frontend into your own hands if you do this.

This PR closes #101.