### PR TITLE
Restrict Prettier to the /js directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# exclude everything
+/*
+
+# except js
+!/js


### PR DESCRIPTION
Hi! First-time contributor here 👋 

<br>

Add a `.prettierignore` file so that Prettier only operates on the `/js` directory.

(TIL: about negative patterns — https://github.com/prettier/prettier/issues/3328)

<br>

This closes https://github.com/jameslittle230/stork/issues/136