### PR TITLE
Improve build stats script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -eux
 
-yarn webpack -v || yarn install
 cargo build --release
+yarn webpack -v || yarn install
 yarn build:wasm:prod
 yarn build:test-index:federalist
 yarn build:js:prod


### PR DESCRIPTION
Rewrite stats script to run benchmarks via `cargo criterion` and output JSON, fixing up a launchtime pain point.