### PR TITLE
If src_url is missing from file, assume value is url field instead

### DIFF
--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -9,8 +9,10 @@ type Fields = HashMap<String, String>;
 pub struct File {
     pub title: String,
     pub url: String,
+
+    /// Implicit source will take from the destination URL
     #[serde(flatten)]
-    pub source: DataSource,
+    pub explicit_source: Option<DataSource>,
 
     pub id: Option<String>,
     #[serde(default)]
@@ -29,12 +31,21 @@ pub struct File {
     pub fields: Fields,
 }
 
+impl File {
+    pub fn source(&self) -> DataSource {
+        match &self.explicit_source {
+            Some(source) => source.clone(),
+            None => DataSource::URL(self.url.clone()),
+        }
+    }
+}
+
 impl fmt::Display for File {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",
-            match &self.source {
+            match &self.source() {
                 DataSource::FilePath(path) => path,
                 DataSource::Contents(_contents) => &self.title,
                 DataSource::URL(url) => url,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -235,7 +235,7 @@ files = [{title = "Derp"}]
     }
 
     #[test]
-    fn file_with_title_and_url_not_allowed() -> Result<(), Error> {
+    fn file_with_title_and_url_assumes_url_is_source() -> Result<(), Error> {
         let contents = r#"
 [[input.files]]
 title = "Derp"
@@ -243,12 +243,16 @@ url = "blorp"
     "#;
         let config: Config = toml::from_str(contents)?;
         let file = config.input.files.first().unwrap();
+
         assert!(file.explicit_source.is_none());
-        assert!(if let DataSource::URL(generated_url) = file.source() {
-            generated_url == "blorp"
-        } else {
-            false
-        });
+        assert!(
+            if let DataSource::URL(generated_url) = file.source() {
+                generated_url == "blorp"
+            } else {
+                false
+            },
+            "URL in computed source is not the same URL as was in the config file!"
+        );
 
         Ok(())
     }

--- a/src/index_versions/v3/builder/fill_intermediate_entries.rs
+++ b/src/index_versions/v3/builder/fill_intermediate_entries.rs
@@ -27,7 +27,7 @@ pub(super) fn fill_intermediate_entries(
     );
 
     let url_file_count: u32 = config.input.files.iter().fold(0, |acc, file| {
-        if let DataSource::URL(_) = file.source {
+        if let DataSource::URL(_) = file.source() {
             acc + 1
         } else {
             acc
@@ -65,7 +65,7 @@ pub(super) fn fill_intermediate_entries(
         &progress_bar.set_message(message);
         &progress_bar.tick();
 
-        let buffer: String = match &stork_file.source {
+        let buffer: String = match &stork_file.source() {
             DataSource::Contents(contents) => contents.to_string(),
 
             DataSource::FilePath(path_string) => {
@@ -175,7 +175,7 @@ pub(super) fn fill_intermediate_entries(
         };
 
         let filetype_from_extension = {
-            match &stork_file.source {
+            match &stork_file.source() {
                 DataSource::FilePath(path_string) => get_filetype_from_extension(&path_string),
                 _ => None,
             }

--- a/src/index_versions/v3/builder/fill_intermediate_entries.rs
+++ b/src/index_versions/v3/builder/fill_intermediate_entries.rs
@@ -62,8 +62,8 @@ pub(super) fn fill_intermediate_entries(
             message.push_str(truncation_prefix)
         }
 
-        &progress_bar.set_message(message);
-        &progress_bar.tick();
+        progress_bar.set_message(message);
+        progress_bar.tick();
 
         let buffer: String = match &stork_file.source() {
             DataSource::Contents(contents) => contents.to_string(),
@@ -163,13 +163,10 @@ pub(super) fn fill_intermediate_entries(
             let path = Path::new(&path_string);
             let ext_str = path.extension()?.to_str()?;
             match String::from(ext_str).to_ascii_lowercase().as_ref() {
-                "html" => Some(Filetype::HTML),
-                "htm" => Some(Filetype::HTML),
+                "html" | "htm" => Some(Filetype::HTML),
                 "srt" => Some(Filetype::SRTSubtitle),
                 "txt" => Some(Filetype::PlainText),
-                "md" => Some(Filetype::Markdown),
-                "mdown" => Some(Filetype::Markdown),
-                "markdown" => Some(Filetype::Markdown),
+                "markdown" | "mdown" | "md" => Some(Filetype::Markdown),
                 _ => None,
             }
         };

--- a/src/index_versions/v3/builder/mod.rs
+++ b/src/index_versions/v3/builder/mod.rs
@@ -103,7 +103,7 @@ mod tests {
 
     fn generate_invalid_file_missing_selector() -> File {
         File {
-            source: DataSource::Contents("".to_string()),
+            explicit_source: Some(DataSource::Contents("".to_string())),
             title: "Missing Selector".to_string(),
             filetype: Some(Filetype::HTML),
             html_selector_override: Some(".article".to_string()),
@@ -113,7 +113,7 @@ mod tests {
 
     fn generate_invalid_file_empty_contents() -> File {
         File {
-            source: DataSource::Contents("".to_string()),
+            explicit_source: Some(DataSource::Contents("".to_string())),
             title: "Empty Contents".to_string(),
             filetype: Some(Filetype::PlainText),
             ..Default::default()
@@ -122,7 +122,7 @@ mod tests {
 
     fn generate_valid_file() -> File {
         File {
-            source: DataSource::Contents("This is contents".to_string()),
+            explicit_source: Some(DataSource::Contents("This is contents".to_string())),
             title: "Successful File".to_string(),
             filetype: Some(Filetype::PlainText),
             ..Default::default()

--- a/test/bowdoin-orient-config/bowdoin-orient.toml
+++ b/test/bowdoin-orient-config/bowdoin-orient.toml
@@ -2,37 +2,30 @@
 html_selector = "main > article.post > .single__content"
 
 [[input.files]]
-src_url = "https://bowdoinorient.com/2021/02/19/from-zoom-hangouts-to-soup-cans-bowdoins-crew-team-gets-creative-during-social-distancing/"
 url = "https://bowdoinorient.com/2021/02/19/from-zoom-hangouts-to-soup-cans-bowdoins-crew-team-gets-creative-during-social-distancing/"
 title = "From Zoom hangouts to soup cans: Bowdoin’s crew team gets creative during social distancing"
 
 [[input.files]]
-src_url = "https://bowdoinorient.com/2021/02/19/pond-hockey-until-watson-opens-womens-hockey-stays-focused-on-virtual-team-bonding/"
 url = "https://bowdoinorient.com/2021/02/19/pond-hockey-until-watson-opens-womens-hockey-stays-focused-on-virtual-team-bonding/"
 title = "Pond hockey: until Watson opens women’s hockey stays focused on virtual team bonding"
 
 [[input.files]]
-src_url = "https://bowdoinorient.com/2021/02/19/embracing-technology-and-social-media-bowdoin-athletics-masters-new-tools-for-recruiting/"
 url = "https://bowdoinorient.com/2021/02/19/embracing-technology-and-social-media-bowdoin-athletics-masters-new-tools-for-recruiting/"
 title = "Embracing technology and social media, Bowdoin athletics masters new tools for recruiting"
 
 [[input.files]]
-src_url = "https://bowdoinorient.com/2021/02/19/bowdoin-health-services-manages-in-person-visits-and-testing-looks-to-vaccinate-students/"
 url = "https://bowdoinorient.com/2021/02/19/bowdoin-health-services-manages-in-person-visits-and-testing-looks-to-vaccinate-students/"
 title = "Bowdoin Health Services manages in-person visits and testing, looks to vaccinate students"
 
 [[input.files]]
-src_url = "https://bowdoinorient.com/2021/02/18/students-reflect-on-their-decisions-to-take-personal-leaves-of-absence/"
 url = "https://bowdoinorient.com/2021/02/18/students-reflect-on-their-decisions-to-take-personal-leaves-of-absence/"
 title = "Students reflect on their decisions to take personal leaves of absence"
 
 [[input.files]]
-src_url = "https://bowdoinorient.com/2021/02/18/college-reports-125-conduct-violations-during-fall-semester-launches-covid-conduct-dashboard/"
 url = "https://bowdoinorient.com/2021/02/18/college-reports-125-conduct-violations-during-fall-semester-launches-covid-conduct-dashboard/"
 title = "College reports 125 conduct violations during fall semester; launches COVID conduct dashboard"
 
 [[input.files]]
-src_url = "https://bowdoinorient.com/2020/02/18/college-reports-125-conduct-violations-during-fall-semester-launches-covid-conduct-dashboard/"
 url = "https://bowdoinorient.com/2020/02/18/college-reports-125-conduct-violations-during-fall-semester-launches-covid-conduct-dashboard/"
 title = "This URL does not exist."
 


### PR DESCRIPTION
Now, the config file can look like:

```toml
[input]
html_selector = "main > article.post > .single__content"

[[input.files]]
url = "https://bowdoinorient.com/2021/02/19/from-zoom-hangouts-to-soup-cans-bowdoins-crew-team-gets-creative-during-social-distancing/"
title = "From Zoom hangouts to soup cans: Bowdoin’s crew team gets creative during social distancing"

[[input.files]]
url = "https://bowdoinorient.com/2021/02/19/pond-hockey-until-watson-opens-womens-hockey-stays-focused-on-virtual-team-bonding/"
title = "Pond hockey: until Watson opens women’s hockey stays focused on virtual team bonding"

[[input.files]]
url = "https://bowdoinorient.com/2021/02/19/embracing-technology-and-social-media-bowdoin-athletics-masters-new-tools-for-recruiting/"
title = "Embracing technology and social media, Bowdoin athletics masters new tools for recruiting"
```

instead of

```toml
[input]
html_selector = "main > article.post > .single__content"

[[input.files]]
src_url = "https://bowdoinorient.com/2021/02/19/from-zoom-hangouts-to-soup-cans-bowdoins-crew-team-gets-creative-during-social-distancing/"
url = "https://bowdoinorient.com/2021/02/19/from-zoom-hangouts-to-soup-cans-bowdoins-crew-team-gets-creative-during-social-distancing/"
title = "From Zoom hangouts to soup cans: Bowdoin’s crew team gets creative during social distancing"

[[input.files]]
src_url = "https://bowdoinorient.com/2021/02/19/pond-hockey-until-watson-opens-womens-hockey-stays-focused-on-virtual-team-bonding/"
url = "https://bowdoinorient.com/2021/02/19/pond-hockey-until-watson-opens-womens-hockey-stays-focused-on-virtual-team-bonding/"
title = "Pond hockey: until Watson opens women’s hockey stays focused on virtual team bonding"

[[input.files]]
src_url = "https://bowdoinorient.com/2021/02/19/embracing-technology-and-social-media-bowdoin-athletics-masters-new-tools-for-recruiting/"
url = "https://bowdoinorient.com/2021/02/19/embracing-technology-and-social-media-bowdoin-athletics-masters-new-tools-for-recruiting/"
title = "Embracing technology and social media, Bowdoin athletics masters new tools for recruiting"
```