### PR TITLE
Use semantic HTML for search highlight

### DIFF
--- a/js/pencil.ts
+++ b/js/pencil.ts
@@ -13,8 +13,8 @@ export function highlight(
   let charactersAlreadyAdded = 0;
 
   for (const range of highlight_ranges) {
-    const beginningInsertion = `<span class="stork-highlight">`;
-    const endInsertion = `</span>`;
+    const beginningInsertion = `<mark class="stork-highlight">`;
+    const endInsertion = `</mark>`;
 
     text = insert(
       text,


### PR DESCRIPTION
Use the `<mark>` tag to highlight the search result, to increase semantics. 
See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark#usage_notes second bullet point.