### PR TITLE
Rename cli binary to `stork` from default `stork-cli`

### DIFF
--- a/stork-cli/Cargo.toml
+++ b/stork-cli/Cargo.toml
@@ -21,3 +21,7 @@ serde = "1.0.130"
 serde_json = "1.0.68"
 stork-lib = { path = "../stork-lib", default-features = false }
 thiserror = "1.0.29"
+
+[[bin]]
+name = "stork"
+path = "src/main.rs"


### PR DESCRIPTION
Fixes #218