### PR TITLE
Handle early user searches

### DIFF
--- a/js/entity.test.ts
+++ b/js/entity.test.ts
@@ -72,3 +72,16 @@ test("Errored download calls render with an error", () => {
   expect(lastCall.state).toEqual("error");
   expect(lastCall.message.toLowerCase()).toContain("error");
 });
+
+test("Changing entity state to ready with a prefilled input performs a search", () => {
+  const entity = new Entity("test", "https://google.com", defaultConfig);
+  jest.spyOn(entity, "performSearch");
+
+  const entityDomWithPrefilledQuery = {
+    getQuery: () => "not empty"
+  };
+
+  entity.domManager = entityDomWithPrefilledQuery as any;
+  entity.state = "ready";
+  expect(entity.performSearch as jest.Mock).toHaveBeenCalledTimes(1);
+});

--- a/js/entity.ts
+++ b/js/entity.ts
@@ -37,6 +37,18 @@ export class Entity {
 
   public set state(value: EntityState) {
     this._state = value;
+
+    // The user can enter a query while the index is being registered
+    if (this._state == "ready") {
+      const query = this.domManager?.getQuery();
+      if (query && query != "") {
+        this.performSearch(query);
+      } else {
+        this.render();
+      }
+      return
+    }
+
     this.render();
   }
 

--- a/js/entity.ts
+++ b/js/entity.ts
@@ -43,10 +43,8 @@ export class Entity {
       const query = this.domManager?.getQuery();
       if (query && query != "") {
         this.performSearch(query);
-      } else {
-        this.render();
+        return
       }
-      return
     }
 
     this.render();


### PR DESCRIPTION
Hello!

I created a PR with a quick fix to better explain what's happening in https://github.com/jameslittle230/stork/issues/217.

I don't expect this PR to be merged as is (it's not super elegant and I'm still learning the code base) – but perhaps it can be used as inspiration for how to address the issue.

The unit test has an in-lined mock (perhaps it's time for an `entityDom` mock).
