### PR TITLE
Use the indexer's string split algorithm

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 - Fixes a Javascript runtime bug where registered indexes weren't always reporting as ready
 - Fixes a crash when the indexed contents contained words longer than 128 characters
 - The `--timings` flag previously did nothing. Now, when included with the `build` or `search` subcommands, timing information will be displayed at the end of the terminal output via stderr.
+- Document titles that were comprised of several words separated by hyphens would crash the search interface. This has been fixed.
 
 ## v1.3.0
 

--- a/stork-index-v3/src/search/entry_and_intermediate_excerpts.rs
+++ b/stork-index-v3/src/search/entry_and_intermediate_excerpts.rs
@@ -131,7 +131,10 @@ impl From<EntryAndIntermediateExcerpts> for Result {
         excerpts.sort_by_key(|e| -(e.score as i16));
         excerpts.truncate(data.config.excerpts_per_result as usize);
 
-        let split_title: Vec<&str> = entry.title.split_whitespace().collect();
+        let split_title: Vec<&str> = entry
+            .title
+            .split(|c: char| c.is_ascii_whitespace() || c == '-')
+            .collect();
         let mut title_highlight_ranges: Vec<HighlightRange> = data
             .intermediate_excerpts
             .iter()

--- a/stork-index-v3/src/search/entry_and_intermediate_excerpts.rs
+++ b/stork-index-v3/src/search/entry_and_intermediate_excerpts.rs
@@ -348,4 +348,30 @@ mod tests {
             computed_first_word
         );
     }
+
+    #[test]
+    fn title_highlighting_works_when_title_has_no_spaces() {
+        let entry_and_intermediate_excerpts = EntryAndIntermediateExcerpts {
+            entry: Entry {
+                contents: "".to_string(),
+                title: "api-methods-animate".to_string(),
+                url: String::default(),
+                fields: HashMap::default(),
+            },
+            config: PassthroughConfig::default(),
+            intermediate_excerpts: vec![IntermediateExcerpt {
+                query: "anim".to_string(),
+                entry_index: 0,
+                score: 128,
+                source: WordListSource::Title,
+                word_index: 2,
+                internal_annotations: Vec::default(),
+                fields: HashMap::default(),
+            }],
+        };
+
+        let output_result = Result::from(entry_and_intermediate_excerpts);
+
+        dbg!(output_result);
+    }
 }


### PR DESCRIPTION
Fixes #236.

This is a hairy part of the code, and highlighting still isn't up to par, but this will at least stop the searcher from crashing as described in the issue.