### PR TITLE
Convert all HashMap usage to BTreeMap

### DIFF
--- a/stork-lib/src/index_v3/build/fill_containers.rs
+++ b/stork-lib/src/index_v3/build/fill_containers.rs
@@ -1,5 +1,5 @@
 use rust_stemmers::Stemmer;
-use std::{collections::HashMap, convert::TryInto, ops::Range};
+use std::{collections::BTreeMap, convert::TryInto, ops::Range};
 
 use crate::{
     config::Config,
@@ -17,8 +17,8 @@ use super::{
 pub fn fill_containers(
     config: &Config,
     intermediate_entries: &[NormalizedEntry],
-    stems: &HashMap<String, Vec<String>>,
-    containers: &mut HashMap<String, Container>,
+    stems: &BTreeMap<String, Vec<String>>,
+    containers: &mut BTreeMap<String, Container>,
 ) {
     for (entry_index, entry) in intermediate_entries.iter().enumerate() {
         let words_in_title: Vec<AnnotatedWord> = entry.title.make_annotated_words();
@@ -70,7 +70,7 @@ pub fn fill_containers(
 }
 
 fn fill_container_results_map(
-    containers: &mut HashMap<String, Container>,
+    containers: &mut BTreeMap<String, Container>,
     normalized_word: &str,
     word_index: usize,
     entry_index: usize,
@@ -97,7 +97,7 @@ fn fill_container_results_map(
 fn fill_other_containers_alias_maps_with_prefixes(
     prefix_length: u8,
     ideograph_prefix_length: u8,
-    containers: &mut HashMap<String, Container>,
+    containers: &mut BTreeMap<String, Container>,
     normalized_word: &str,
 ) {
     let chars: Vec<char> = normalized_word.chars().collect();
@@ -125,8 +125,8 @@ fn fill_other_containers_alias_maps_with_prefixes(
 
 fn fill_other_containers_alias_maps_with_reverse_stems(
     entry: &NormalizedEntry,
-    stems: &HashMap<String, Vec<String>>,
-    containers: &mut HashMap<String, Container>,
+    stems: &BTreeMap<String, Vec<String>>,
+    containers: &mut BTreeMap<String, Container>,
     normalized_word: &str,
 ) {
     if let Some(stem_algorithm) = entry.stem_algorithm {
@@ -194,7 +194,7 @@ mod tests {
         config::Config,
         index_v3::{build::intermediate_entry::NormalizedEntry, AnnotatedWordList},
     };
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use super::fill_containers;
 
@@ -208,12 +208,12 @@ mod tests {
             stem_algorithm: None,
         };
 
-        let mut containers = HashMap::default();
+        let mut containers = BTreeMap::default();
 
         fill_containers(
             &Config::default(),
             &[intermediate_entry],
-            &HashMap::default(),
+            &BTreeMap::default(),
             &mut containers,
         );
 

--- a/stork-lib/src/index_v3/build/fill_stems.rs
+++ b/stork-lib/src/index_v3/build/fill_stems.rs
@@ -1,10 +1,10 @@
 use super::{remove_surrounding_punctuation, NormalizedEntry};
 use rust_stemmers::Stemmer;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub fn fill_stems(
     intermediate_entries: &[NormalizedEntry],
-    stems: &mut HashMap<String, Vec<String>>,
+    stems: &mut BTreeMap<String, Vec<String>>,
 ) {
     for entry in intermediate_entries {
         let contents = &entry.annotated_word_list;

--- a/stork-lib/src/index_v3/build/mod.rs
+++ b/stork-lib/src/index_v3/build/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 mod fill_containers;
 mod fill_intermediate_entries;
@@ -40,13 +40,16 @@ pub fn build(config: &Config) -> Result<BuildResult, IndexGenerationError> {
         return Err(IndexGenerationError::NoValidFiles);
     }
 
-    let mut stems: HashMap<String, Vec<String>> = HashMap::new();
+    let mut stems: BTreeMap<String, Vec<String>> = BTreeMap::new();
     fill_stems(&intermediate_entries, &mut stems);
 
-    let mut containers: HashMap<String, Container> = HashMap::new();
+    let mut containers: BTreeMap<String, Container> = BTreeMap::new();
     fill_containers(config, &intermediate_entries, &stems, &mut containers);
 
-    let entries: Vec<Entry> = intermediate_entries.iter().map(Entry::from).collect();
+    let entries: Vec<Entry> = intermediate_entries
+        .iter()
+        .map(Entry::from)
+        .collect::<Vec<Entry>>();
 
     let passthrough_config = PassthroughConfig {
         url_prefix: config.input.url_prefix.clone(),

--- a/stork-lib/src/index_v3/mod.rs
+++ b/stork-lib/src/index_v3/mod.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use smart_default::SmartDefault;
 
@@ -35,7 +35,7 @@ mod write;
 pub struct Index {
     config: PassthroughConfig,
     entries: Vec<Entry>,
-    containers: HashMap<String, Container>,
+    containers: BTreeMap<String, Container>,
 }
 
 impl Index {
@@ -89,10 +89,10 @@ struct Entry {
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Container {
     // #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    results: HashMap<EntryIndex, SearchResult>,
+    results: BTreeMap<EntryIndex, SearchResult>,
 
     // #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    aliases: HashMap<AliasTarget, Score>,
+    aliases: BTreeMap<AliasTarget, Score>,
 }
 
 impl Container {
@@ -166,6 +166,7 @@ impl AnnotatedWordList {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use std::convert::TryFrom;
     use std::fs;
     use std::io::{BufReader, Read};

--- a/stork-lib/src/index_v3/search/mod.rs
+++ b/stork-lib/src/index_v3/search/mod.rs
@@ -1,5 +1,5 @@
 pub mod intermediate_excerpt;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use intermediate_excerpt::IntermediateExcerpt;
 
@@ -41,7 +41,7 @@ pub fn search(index: &Index, query: &str) -> Output {
         }
     }
 
-    let mut excerpts_by_index: HashMap<EntryIndex, Vec<IntermediateExcerpt>> = HashMap::new();
+    let mut excerpts_by_index: BTreeMap<EntryIndex, Vec<IntermediateExcerpt>> = BTreeMap::new();
     for ie in intermediate_excerpts {
         excerpts_by_index
             .entry(ie.entry_index)
@@ -74,8 +74,8 @@ pub fn search(index: &Index, query: &str) -> Output {
 }
 
 struct ContainerWithQuery {
-    results: HashMap<EntryIndex, SearchResult>,
-    aliases: HashMap<AliasTarget, Score>,
+    results: BTreeMap<EntryIndex, SearchResult>,
+    aliases: BTreeMap<AliasTarget, Score>,
     query: String,
 }
 


### PR DESCRIPTION
Fixes #261 

```sh
❯ while TRUE; cargo run -- build --input local-dev/test-configs/federalist.toml --output test.st 2> /dev/null && sha256sum test.st; end
05ece8e36d4c1abc4362f3969c304288a26500a81df05d37f324ba709581e955  test.st
05ece8e36d4c1abc4362f3969c304288a26500a81df05d37f324ba709581e955  test.st
05ece8e36d4c1abc4362f3969c304288a26500a81df05d37f324ba709581e955  test.st
05ece8e36d4c1abc4362f3969c304288a26500a81df05d37f324ba709581e955  test.st
```

This is achieved by using a BTreeMap instead of a Hashmap in the Index data structure. This looks like it slows down build times a lot; I'm not sure what effect it has on search times.

Alternatively, I could only convert to a BTreeMap when it comes time to serialize, as described in https://stackoverflow.com/a/42723390 - let's see how metrics look first though.