### PR TITLE
Fix the test server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,6 +1516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,6 +1619,7 @@ dependencies = [
  "bytes",
  "clap",
  "colored",
+ "hyper",
  "num-format",
  "pretty_assertions",
  "serde",
@@ -1617,6 +1627,7 @@ dependencies = [
  "stork-lib",
  "textwrap 0.14.2",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1802,7 +1813,9 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "winapi",
 ]

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.4.2
+
+### Bug Fixes
+
+- Fixes a regression where the test server (`stork test`) was inaccessible
+
 ## v1.4.1
 
 [Mar 12, 2022](https://github.com/jameslittle230/stork/releases/tag/v1.4.1)

--- a/stork-cli/Cargo.toml
+++ b/stork-cli/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["wasm"]
 
 [features]
 default = ["v1-compat", "search-v2", "search-v3", "build-v3-web-scraping"]
+test-server = ["hyper", "tokio"]
 v1-compat = []
 search-v2 = ["stork-lib/search-v2"]
 search-v3 = ["stork-lib/search-v3"]
@@ -24,12 +25,14 @@ atty = "0.2.14"
 bytes = "1.1.0"
 clap = { version = "2.33.3", features = ["color"] }
 colored = "2.0.0"
+hyper = { version = "0.14.17", optional = true, features = ["server"] }
 num-format = "0.4.0"
 serde = "1.0.130"
 serde_json = "1.0.68"
 stork-lib = { path = "../stork-lib", version = "1.4.1", default-features = false }
 textwrap = { version = "0.14.2", features = ["terminal_size"] }
 thiserror = "1.0.29"
+tokio = { version = "1.17.0", optional = true, features = ["signal"] }
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"

--- a/stork-cli/src/clap.rs
+++ b/stork-cli/src/clap.rs
@@ -111,7 +111,7 @@ pub fn app() -> App<'static, 'static> {
                         .help("The path to your configuration file, or - for stdin")
                         .takes_value(true)
                         .value_name("CONFIG_PATH")
-                        .required(false)
+                        .required(true)
                         .conflicts_with("index_path"),
                 )
                 .arg(
@@ -130,7 +130,7 @@ pub fn app() -> App<'static, 'static> {
                         .help("The path to your index file")
                         .takes_value(true)
                         .value_name("INDEX_PATH")
-                        .required(false)
+                        .required(true)
                         .conflicts_with("config"),
                 )
         )

--- a/stork-cli/src/errors.rs
+++ b/stork-cli/src/errors.rs
@@ -2,6 +2,7 @@ use std::{io, num::ParseIntError};
 use stork_lib::{BuildError, ConfigReadError, IndexParseError, SearchError};
 use thiserror::Error;
 
+#[allow(dead_code)]
 #[derive(Debug, Error)]
 pub enum StorkCommandLineError {
     #[error("Couldn't read the configuration file: {0}")]
@@ -37,6 +38,9 @@ pub enum StorkCommandLineError {
     #[error("Couldn't display search results as JSON. Got error `{0}`")]
     SearchResultJsonSerializationError(#[from] serde_json::Error),
 
-    #[error("`{0}`")]
+    #[error("{0}")]
     InvalidCommandLineArguments(&'static str),
+
+    #[error("{0}")]
+    NotCompiledWithFeature(&'static str),
 }

--- a/stork-cli/src/main.rs
+++ b/stork-cli/src/main.rs
@@ -196,8 +196,6 @@ fn test_handler(submatches: &ArgMatches) -> CmdResult {
         let index = read_bytes_from_path(index_path)?;
         test_server::serve(&index, port).map_err(|_| StorkCommandLineError::ServerError)
     } else {
-        Err(StorkCommandLineError::InvalidCommandLineArguments(
-            "Test server requires either --config or --index",
-        ))
+        unreachable!()
     }
 }

--- a/stork-cli/src/main.rs
+++ b/stork-cli/src/main.rs
@@ -184,7 +184,7 @@ fn test_handler(submatches: &ArgMatches) -> CmdResult {
         let config = Config::try_from(config_string.as_str())?;
         let output = build_index(&config)?;
         test_server::serve(&output.bytes, port).map_err(|_| StorkCommandLineError::ServerError)
-    } else if let Some(index_path) = submatches.value_of("index") {
+    } else if let Some(index_path) = submatches.value_of("index_path") {
         let index = read_bytes_from_path(index_path)?;
         test_server::serve(&index, port).map_err(|_| StorkCommandLineError::ServerError)
     } else {

--- a/stork-cli/src/main.rs
+++ b/stork-cli/src/main.rs
@@ -7,6 +7,8 @@ mod display_timings;
 mod errors;
 mod io;
 mod pretty_print_search_results;
+
+#[cfg(feature = "test-server")]
 mod test_server;
 
 use crate::clap::app;
@@ -173,6 +175,12 @@ fn search_handler(submatches: &ArgMatches) -> CmdResult {
     Ok(())
 }
 
+#[cfg(not(feature = "test-server"))]
+fn test_handler(_: &ArgMatches) -> CmdResult {
+    Err(StorkCommandLineError::NotCompiledWithFeature("Stork was not compiled with test server support. Rebuild the crate with default features to enable the test server.\nIf you don't expect to see this, file a bug: https://jil.im/storkbug"))
+}
+
+#[cfg(feature = "test-server")]
 fn test_handler(submatches: &ArgMatches) -> CmdResult {
     let port_string = submatches.value_of("port").unwrap();
     let port = port_string

--- a/stork-cli/src/test_server/index.html
+++ b/stork-cli/src/test_server/index.html
@@ -3,52 +3,59 @@
   <head>
     <meta charset="utf-8" />
     <title>Stork Search</title>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🔎</text></svg>">
-    <link rel="stylesheet" href="https://files.stork-search.net/basic.css" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🔎</text></svg>"
+    />
+    <link
+      rel="stylesheet"
+      href="https://files.stork-search.net/releases/v{0}/basic.css"
+    />
     <style>
-      .search-wrap {
+      .search-wrap {{
         max-width: 1200px;
         display: flex;
         flex-direction: column;
-      }
-      
-      .stork-wrapper {
+      }}
+
+      .stork-wrapper {{
         max-width: 550px;
         width: 100%;
         margin-bottom: 3rem;
-      }
+      }}
 
-      .stork-output-visible {
+      .stork-output-visible {{
         z-index: 200;
-      }
-
-      .subtitle {
-        margin: 0.8em;
-        font-weight: bold;
-        text-transform: uppercase;
-        font-size: 0.8em;
-      }
-      body {
-        background-color: #DDD;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      }}
+      body {{
+        background-color: #ddd;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+          "Segoe UI Symbol";
         padding: 2rem;
-      }
+      }}
 
-      h1 {
+      h1 {{
         margin-top: 0;
-      }
+      }}
     </style>
   </head>
   <body>
     <h1>Stork Test Page</h1>
-    <p>Found a bug? <a href="https://github.com/jameslittle230/stork/issues/new">Report it! →</a></p>
-    <div class="search-wrap">
-      <div class="stork-wrapper">
-        <input data-stork="test" placeholder="Search..." class="stork-input"></input>
-        <div data-stork="test-output" class="stork-output"></div>
-      </div>
+    <p>
+      Found a bug?
+      <a href="https://github.com/jameslittle230/stork/issues/new"
+        >Report it! →</a
+      >
+    </p>
+    <div class="stork-wrapper">
+      <input data-stork="test" placeholder="Search..." class="stork-input" />
+      <div data-stork="test-output" class="stork-output"></div>
+    </div>
 
-    <script src="https://files.stork-search.net/stork.js"></script>
-    <script>stork.register("test", "/test.st");</script>
+    <script src="https://files.stork-search.net/releases/v{0}/stork.js"></script>
+    <script>
+      stork.register("test", "/test.st");
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Problems:
- The feature was hidden behind a Cargo `feature` that didn't exist, so it was never being compiled in
- The feature was out of date and didn't compile as-is
- The demo webpage referenced old CDN assets
- The value of the `index_path` command line argument wasn't being extracted properly since I was querying it with the incorrect string `index`

Fixes #269 