### PR TITLE
Add transformResultUrl callback to JS API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.5.0
+
+### New Features
+
+- Adds the Javascript registration option `transformResultUrl`, which, when
+  set, transforms search result URLs from what's described in the search index
+  to what gets output in the DOM.
+
 ## v1.4.2
 
 [Mar 22, 2022](https://github.com/jameslittle230/stork/releases/tag/v1.4.2)

--- a/js/config.ts
+++ b/js/config.ts
@@ -13,6 +13,7 @@ export interface Configuration {
   onResultSelected?: (query: string, result: unknown) => unknown;
   onResultsHidden?: () => unknown;
   onInputCleared?: () => unknown;
+  transformResultUrl: (url: string) => string;
 }
 
 export const defaultConfig: Readonly<Configuration> = {
@@ -26,7 +27,8 @@ export const defaultConfig: Readonly<Configuration> = {
   onQueryUpdate: undefined,
   onResultSelected: undefined,
   onResultsHidden: undefined,
-  onInputCleared: undefined
+  onInputCleared: undefined,
+  transformResultUrl: url => url,
 };
 
 export function calculateOverriddenConfig(

--- a/js/entity.ts
+++ b/js/entity.ts
@@ -132,7 +132,7 @@ export class Entity {
       ) {
         urlSuffix = r.excerpts[0].internal_annotations[0]["a"];
       }
-      r.entry.url = `${urlPrefix}${r.entry.url}${urlSuffix}`;
+      r.entry.url = this.config.transformResultUrl(`${urlPrefix}${r.entry.url}${urlSuffix}`);
     });
 
     this.render();


### PR DESCRIPTION
Transforming result URLs allows the user to build sites that are relocatable rather anchored on the site root (for instance, by prepending the resulting URL with the relative path to the root directory).

I'm sure other uses exist too, but this is what I need it for.

Thanks