### PR TITLE
Fix crash when parsing Markdown content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,17 +790,6 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
-name = "markdown"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3aab6a1d529b112695f72beec5ee80e729cb45af58663ec902c8fac764ecdd"
-dependencies = [
- "lazy_static",
- "pipeline",
- "regex",
-]
 
 [[package]]
 name = "markup5ever"
@@ -1091,12 +1089,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pipeline"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15b6607fa632996eb8a17c9041cb6071cb75ac057abd45dece578723ea8c7c0"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1159,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f197a544b0c9ab3ae46c359a7ec9cbbb5c7bf97054266fecb7ead794a181d6"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -1595,10 +1599,10 @@ dependencies = [
  "indicatif",
  "kuchiki",
  "lazy_static",
- "markdown",
  "mime",
  "num-format",
  "pretty_assertions",
+ "pulldown-cmark",
  "reqwest",
  "rmp-serde",
  "rust-stemmers",
@@ -1886,6 +1890,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +1969,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 
 - Fixes a bug where multiple instances of the element described in the
   `exclude_html_selector` configuration option were not being correctly excluded.
+- Fixes a crash when trying to parse noncompliant Markdown contents
 
 ## v1.4.2
 

--- a/stork-lib/Cargo.toml
+++ b/stork-lib/Cargo.toml
@@ -19,7 +19,7 @@ search-v3 = ["rmp-serde"]
 build-v3 = [
     "search-v3",
     "num-format",
-    "markdown",
+    "pulldown-cmark",
     "mime",
     "srtparse",
     "kuchiki",
@@ -42,7 +42,7 @@ toml = "0.5.8"
 frontmatter = { version = "0.4.0", optional = true }
 indicatif = { version = "0.16.2", optional = true }
 kuchiki = { version = "0.8.1", optional = true }
-markdown = { version = "0.3.0", optional = true }
+pulldown-cmark = { version = "0.9.1", optional = true }
 mime = { version = "0.3.16", optional = true }
 reqwest = { version = "0.11", features = ["blocking", "json"], optional = true }
 rmp-serde = { version = "0.15.5", optional = true }

--- a/stork-lib/src/index_v3/build/fill_intermediate_entries/data_source_readers/mod.rs
+++ b/stork-lib/src/index_v3/build/fill_intermediate_entries/data_source_readers/mod.rs
@@ -24,3 +24,53 @@ pub fn read_from_data_source(
     }
     .map(|read_result| read_result.extract_frontmatter(reader_config))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use pretty_assertions::assert_eq;
+
+    use crate::{
+        config::{DataSource, File, Filetype, InputConfig, OutputConfig},
+        index_v3::build::fill_intermediate_entries::{ReadResult, ReaderConfig},
+    };
+
+    use super::read_from_data_source;
+
+    #[test]
+    fn read_from_data_source_extracts_frontmatter() {
+        let read_result = read_from_data_source(&ReaderConfig {
+            global: InputConfig {
+                frontmatter_handling: crate::config::FrontmatterConfig::Parse,
+                ..Default::default()
+            },
+            file: File {
+                title: "Input File".to_string(),
+                explicit_source: Some(DataSource::Contents(
+                    r#"---
+key: value
+---
+
+# Header
+
+this _is_ the text"#
+                        .to_string(),
+                )),
+                filetype: Some(Filetype::Markdown),
+                ..Default::default()
+            },
+            output: OutputConfig::default(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            read_result,
+            ReadResult {
+                buffer: "# Header\n\nthis _is_ the text".to_string(),
+                filetype: Some(Filetype::Markdown),
+                frontmatter_fields: Some(HashMap::from([("key".to_string(), "value".to_string())]))
+            }
+        );
+    }
+}

--- a/stork-lib/src/index_v3/build/fill_intermediate_entries/mod.rs
+++ b/stork-lib/src/index_v3/build/fill_intermediate_entries/mod.rs
@@ -21,6 +21,7 @@ use unicode_segmentation::UnicodeSegmentation;
 /**
  * A `DataSourceReader` will output one of these once it's read from the data source.
  */
+#[derive(Debug, PartialEq)]
 pub struct ReadResult {
     pub(super) buffer: String,
 

--- a/stork-lib/src/index_v3/build/fill_intermediate_entries/word_list_generators/markdown_word_list_generator.rs
+++ b/stork-lib/src/index_v3/build/fill_intermediate_entries/word_list_generators/markdown_word_list_generator.rs
@@ -80,6 +80,7 @@ Goodbye!"#
         use super::assert_markdown_content;
 
         #[test]
+        #[rustfmt::skip]
         fn space_after_numeric_list() {
             assert_markdown_content(
                 "something below, there is a space immediately after the 1. above",
@@ -90,13 +91,14 @@ something below, there is a space immediately after the 1. above  "#,
         }
 
         #[test]
+        #[rustfmt::skip]
         fn space_after_bullet_list() {
             assert_markdown_content(
                 "something below, there is a space immediately after the star above", 
     r#"* 
 
-something below, there is a space immediately after the star above  "#
-    );
+something below, there is a space immediately after the star above  "#,
+            );
         }
     }
 }

--- a/stork-lib/src/index_v3/build/fill_intermediate_entries/word_list_generators/markdown_word_list_generator.rs
+++ b/stork-lib/src/index_v3/build/fill_intermediate_entries/word_list_generators/markdown_word_list_generator.rs
@@ -22,6 +22,8 @@ pub fn generate(
 #[cfg(test)]
 mod tests {
 
+    use pretty_assertions::assert_eq;
+
     use crate::{
         config::{File, Filetype, InputConfig, OutputConfig},
         index_v3::build::fill_intermediate_entries::{ReadResult, ReaderConfig},
@@ -29,27 +31,18 @@ mod tests {
 
     use super::generate;
 
-    #[test]
-    fn test_markdown() {
-        let expected = "This is a title Stork should recognize this text This content should be indexed. This is another paragraph with inline text formatting . This is a link. Goodbye!";
+    fn assert_markdown_content(word_list: &str, markdown_content: &str) {
         let computed: String = generate(
             &ReaderConfig {
-                global: InputConfig::default(),
+                global: InputConfig {
+                    frontmatter_handling: crate::config::FrontmatterConfig::Omit,
+                    ..Default::default()
+                },
                 file: File::default(),
                 output: OutputConfig::default(),
             },
             &ReadResult {
-                buffer: r#"
-# This is a title
-
-Stork should recognize this text
-
-- This content should be indexed.
-- This is another paragraph with **_inline text_formatting**.
-- [This is a link.](https://example.com)
-
-Goodbye!"#
-                    .to_string(),
+                buffer: markdown_content.to_string(),
                 filetype: Some(Filetype::Markdown),
                 frontmatter_fields: None,
             },
@@ -61,6 +54,58 @@ Goodbye!"#
         .collect::<Vec<String>>()
         .join(" ");
 
-        assert_eq!(expected, computed);
+        assert_eq!(word_list, computed);
+    }
+
+    #[test]
+    fn test_markdown() {
+        assert_markdown_content(
+            "This is a title Stork should recognize this text This content should be indexed. This is another paragraph with inline text formatting . This is a link. Goodbye!", 
+r#"
+# This is a title
+
+Stork should recognize this text
+
+- This content should be indexed.
+- This is another paragraph with **_inline text_formatting**.
+- [This is a link.](https://example.com)
+
+Goodbye!"#
+);
+    }
+
+    mod issue_290 {
+
+        use super::assert_markdown_content;
+
+        #[test]
+        fn space_after_numeric_list() {
+            assert_markdown_content(
+                "1. something below, there is a space immediately after the 1. above",
+                r#"---
+title: Something
+tags: test
+---
+
+1. 
+
+something below, there is a space immediately after the 1. above  "#,
+            );
+        }
+
+        #[test]
+        fn space_after_bullet_list() {
+            assert_markdown_content(
+                "This is a title Stork should recognize this text This content should be indexed. This is another paragraph with inline text formatting . This is a link. Goodbye!", 
+    r#"---
+title: Something
+tags: test
+---
+
+* 
+
+something below, there is a space immediately after the star above  "#
+    );
+        }
     }
 }

--- a/stork-lib/src/index_v3/build/fill_intermediate_entries/word_list_generators/markdown_word_list_generator.rs
+++ b/stork-lib/src/index_v3/build/fill_intermediate_entries/word_list_generators/markdown_word_list_generator.rs
@@ -1,15 +1,16 @@
-use crate::index_v3::AnnotatedWordList;
-
 use super::{html_word_list_generator, ReadResult, ReaderConfig, WordListGenerationError};
+use crate::index_v3::AnnotatedWordList;
+use pulldown_cmark::{html, Parser};
 
 pub fn generate(
     config: &ReaderConfig,
     read_result: &ReadResult,
 ) -> Result<AnnotatedWordList, WordListGenerationError> {
-    let html_string = format!(
-        "<html><body><main>{}</main></body></html>",
-        markdown::to_html(&read_result.buffer)
-    );
+    let parser = Parser::new(&read_result.buffer);
+    let mut html_output = String::new();
+    html::push_html(&mut html_output, parser);
+
+    let html_string = format!("<html><body><main>{html_output}</main></body></html>");
 
     let html_read_result = ReadResult {
         buffer: html_string,
@@ -81,13 +82,8 @@ Goodbye!"#
         #[test]
         fn space_after_numeric_list() {
             assert_markdown_content(
-                "1. something below, there is a space immediately after the 1. above",
-                r#"---
-title: Something
-tags: test
----
-
-1. 
+                "something below, there is a space immediately after the 1. above",
+                r#"1. 
 
 something below, there is a space immediately after the 1. above  "#,
             );
@@ -96,13 +92,8 @@ something below, there is a space immediately after the 1. above  "#,
         #[test]
         fn space_after_bullet_list() {
             assert_markdown_content(
-                "This is a title Stork should recognize this text This content should be indexed. This is another paragraph with inline text formatting . This is a link. Goodbye!", 
-    r#"---
-title: Something
-tags: test
----
-
-* 
+                "something below, there is a space immediately after the star above", 
+    r#"* 
 
 something below, there is a space immediately after the star above  "#
     );

--- a/stork-lib/src/index_v3/build/fill_intermediate_entries/word_list_generators/markdown_word_list_generator.rs
+++ b/stork-lib/src/index_v3/build/fill_intermediate_entries/word_list_generators/markdown_word_list_generator.rs
@@ -68,7 +68,7 @@ r#"
 Stork should recognize this text
 
 - This content should be indexed.
-- This is another paragraph with **_inline text_formatting**.
+- This is another paragraph with **_inline text_ formatting**.
 - [This is a link.](https://example.com)
 
 Goodbye!"#


### PR DESCRIPTION
Fixes #290 

- [x] Changelog
- [x] Add test to ensure that frontmatter is correctly stripped & parsed from an incoming markdown file