### PR TITLE
Center SVG x in stork-close-button

### DIFF
--- a/themes/basic.css
+++ b/themes/basic.css
@@ -192,6 +192,7 @@
   width: 0.8em;
   position: relative;
   top: 1px;
+  margin: auto;
 }
 
 .stork-wrapper .stork-close-button:hover {

--- a/themes/dark.css
+++ b/themes/dark.css
@@ -196,6 +196,7 @@
   width: 0.8em;
   position: relative;
   top: 1px;
+  margin: auto;
 }
 
 .stork-wrapper-dark .stork-close-button:hover {

--- a/themes/edible-dark.css
+++ b/themes/edible-dark.css
@@ -221,6 +221,7 @@
   width: 0.8em;
   position: relative;
   top: 1px;
+  margin: auto;
 }
 
 .stork-wrapper-edible-dark .stork-close-button:hover {

--- a/themes/edible.css
+++ b/themes/edible.css
@@ -216,6 +216,7 @@
   width: 0.8em;
   position: relative;
   top: 1px;
+  margin: auto;
 }
 
 .stork-wrapper-edible .stork-close-button:hover {

--- a/themes/flat.css
+++ b/themes/flat.css
@@ -179,6 +179,7 @@
 .stork-wrapper-flat .stork-close-button svg {
   width: 11px;
   height: 11px;
+  margin: auto;
 }
 
 .stork-wrapper-flat .stork-close-button:hover {


### PR DESCRIPTION
Add a CSS rule to center the X in the stork-close-button

Before
<img width="583" alt="Capture d’écran 2022-07-30 à 00 49 22" src="https://user-images.githubusercontent.com/2761504/181855186-50629176-a24f-4e9c-bbd9-7a2f91d2dba3.png">

After
<img width="580" alt="Capture d’écran 2022-07-30 à 00 49 11" src="https://user-images.githubusercontent.com/2761504/181855177-3bdc5acf-df96-484a-a82e-a42d2e76ddaf.png">

