### PR TITLE
Fix timestamp formatting to match documentation

### DIFF
--- a/.github/workflows/ci-on-push.yml
+++ b/.github/workflows/ci-on-push.yml
@@ -24,7 +24,6 @@ jobs:
           crate: wasm-pack
       
       - name: Set up just
-        if: steps.cache.outputs.cache-hit != 'true'
         uses: actions-rs/install@v0.1
         with:
           crate: just

--- a/.github/workflows/ci-on-push.yml
+++ b/.github/workflows/ci-on-push.yml
@@ -22,6 +22,12 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: wasm-pack
+      
+      - name: Set up just
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions-rs/install@v0.1
+        with:
+          crate: just
 
       - run: just _rust-test
 

--- a/.github/workflows/ci-on-push.yml
+++ b/.github/workflows/ci-on-push.yml
@@ -23,16 +23,7 @@ jobs:
         with:
           crate: wasm-pack
 
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.15.0'
-          args: '-- --test-threads 1'
-
-      - run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -t ${CODECOV_TOKEN}
+      - run: just _rust-test
 
   js_tests:
     name: "Run JS Tests"

--- a/stork-cli/src/clap.rs
+++ b/stork-cli/src/clap.rs
@@ -173,7 +173,7 @@ mod tests {
         for input in valid_inputs {
             app()
                 .get_matches_from_safe(input.split(' '))
-                .unwrap_or_else(|e| panic!("Error with input {:?}: {}", &input, e));
+                .unwrap_or_else(|e| panic!("Error with input {:?}: {e}", &input));
         }
     }
     #[test]

--- a/stork-cli/src/io.rs
+++ b/stork-cli/src/io.rs
@@ -30,7 +30,7 @@ pub fn read_bytes_from_path(path: &str) -> Result<Bytes, StorkCommandLineError> 
 
     // TODO: Handle path == "" case
     let pathbuf = std::path::PathBuf::from(path);
-    std::fs::read(&pathbuf)
+    std::fs::read(pathbuf)
         .map(Bytes::from)
         .map_err(|e| StorkCommandLineError::FileReadError(path.to_string(), e))
 }
@@ -46,7 +46,7 @@ pub fn read_from_path(path: &str) -> Result<String, StorkCommandLineError> {
         // handle ("", Some) or ("", None), perhaps
         _ => {
             let pathbuf = std::path::PathBuf::from(path);
-            std::fs::read_to_string(&pathbuf)
+            std::fs::read_to_string(pathbuf)
                 .map_err(|e| StorkCommandLineError::FileReadError(path.to_string(), e))
         }
     }

--- a/stork-cli/src/main.rs
+++ b/stork-cli/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
         // Delete when releasing 2.0.0
         (_, _) => {
             fn print_nudging_string(errant_command: &str) {
-                eprintln!("{} The command line interface has been updated: please use `stork {}` instead of `stork --{}`. See `stork --help` for more.", "Warning:".yellow(), errant_command, errant_command);
+                eprintln!("{} The command line interface has been updated: please use `stork {errant_command}` instead of `stork --{errant_command}`. See `stork --help` for more.", "Warning:".yellow());
             }
 
             if let Some(config_path) = app_matches.value_of("build") {
@@ -90,7 +90,7 @@ fn main() {
     };
 
     if let Err(error) = result {
-        eprintln!("{} {}", "Error:".red(), error);
+        eprintln!("{} {error}", "Error:".red());
         exit(EXIT_FAILURE);
     }
 }
@@ -149,7 +149,7 @@ fn search_handler(submatches: &ArgMatches) -> CmdResult {
     match submatches.value_of("format") {
         Some("json") => {
             match serde_json::to_string_pretty(&results).map_err(StorkCommandLineError::from) {
-                Ok(json) => println!("{}", json),
+                Ok(json) => println!("{json}"),
                 Err(error) => {
                     return Err(error);
                 }

--- a/stork-cli/src/pretty_print_search_results.rs
+++ b/stork-cli/src/pretty_print_search_results.rs
@@ -10,7 +10,7 @@ fn highlight_string(string: &str, ranges: &Vec<HighlightRange>) -> String {
     let mut last_end = 0;
     for range in ranges {
         highlighted.push_str(&string[last_end..range.beginning]);
-        highlighted.push_str(&string[range.beginning..range.end].yellow().to_string());
+        highlighted.push_str(&string[range.beginning..range.end].yellow());
         last_end = range.end;
     }
     highlighted.push_str(&string[last_end..]);
@@ -86,7 +86,7 @@ mod tests {
                 }],
             }],
             total_hit_count: 21,
-            url_prefix: "".to_string(),
+            url_prefix: String::new(),
         };
 
         assert_eq!(

--- a/stork-cli/src/test_server/mod.rs
+++ b/stork-cli/src/test_server/mod.rs
@@ -43,10 +43,10 @@ pub fn serve(index: &Bytes, port: u16) -> Result<(), Box<dyn std::error::Error>>
         let server = Server::bind(&addr).serve(make_svc);
         let graceful = server.with_graceful_shutdown(shutdown_signal());
 
-        println!("Open <http://{}> in your web browser to visit the test page.\nPress ctrl-C to stop the server.", addr);
+        println!("Open <http://{addr}> in your web browser to visit the test page.\nPress ctrl-C to stop the server.");
 
         if let Err(e) = graceful.await {
-            eprintln!("server error: {}", e);
+            eprintln!("server error: {e}");
         }
         Ok(())
     })

--- a/stork-lib/src/config/mod.rs
+++ b/stork-lib/src/config/mod.rs
@@ -85,7 +85,7 @@ mod tests {
             input: InputConfig {
                 UNUSED_surrounding_word_count: None,
                 base_directory: "test/federalist".into(),
-                url_prefix: "".into(),
+                url_prefix: String::new(),
                 title_boost: TitleBoost::Moderate,
                 stemming: StemmingConfig::Language(
                     rust_stemmers::Algorithm::English,

--- a/stork-lib/src/config/srt.rs
+++ b/stork-lib/src/config/srt.rs
@@ -16,4 +16,5 @@ pub struct SRTConfig {
 pub enum SRTTimestampFormat {
     #[default]
     NumberOfSeconds,
+    MinutesAndSeconds,
 }

--- a/stork-lib/src/config/stemming.rs
+++ b/stork-lib/src/config/stemming.rs
@@ -30,7 +30,7 @@ impl TryFrom<&String> for StemmingConfig {
             return Ok(StemmingConfig::None);
         }
 
-        toml::from_str(format!("lang = \"{}\"", value).as_str())
+        toml::from_str(format!("lang = \"{value}\"").as_str())
             .map(|t: TempAlgStructure| StemmingConfig::Language(t.lang))
     }
 }
@@ -58,7 +58,7 @@ impl From<StemmingConfig> for String {
     fn from(stemming_config: StemmingConfig) -> Self {
         let mut output = String::new();
         let _result = match stemming_config {
-            StemmingConfig::Language(l) => write!(&mut output, "{:?}", l),
+            StemmingConfig::Language(l) => write!(&mut output, "{l:?}"),
             StemmingConfig::None => write!(&mut output, "none"),
         };
         output

--- a/stork-lib/src/index_v2/search.rs
+++ b/stork-lib/src/index_v2/search.rs
@@ -278,6 +278,6 @@ mod tests {
         //     IndexVersion::from(ParsedIndex::try_from(index_bytes.as_slice()).unwrap()),
         //     IndexVersion::V2
         // );
-        assert_eq!(generated, expected, "{:?}", generated);
+        assert_eq!(generated, expected, "{generated:?}");
     }
 }

--- a/stork-lib/src/index_v3/build/errors.rs
+++ b/stork-lib/src/index_v3/build/errors.rs
@@ -34,7 +34,7 @@ pub enum WordListGenerationError {
 }
 
 fn pluralize_with_count(count: usize, singular: &str, plural: &str) -> String {
-    format!("{} {}", count, if count == 1 { singular } else { plural })
+    format!("{count} {}", if count == 1 { singular } else { plural })
 }
 
 #[derive(Debug, Error)]

--- a/stork-lib/src/index_v3/build/fill_containers.rs
+++ b/stork-lib/src/index_v3/build/fill_containers.rs
@@ -147,7 +147,7 @@ fn fill_other_containers_alias_maps_with_reverse_stems(
                         .or_insert_with(Container::new)
                         .aliases
                         .entry(normalized_word.to_string())
-                        .or_insert(STEM_SCORE as u8);
+                        .or_insert(STEM_SCORE);
                 }
             }
         }
@@ -209,7 +209,7 @@ mod tests {
         let intermediate_entry = NormalizedEntry {
             annotated_word_list: AnnotatedWordList { word_list: vec![] },
             title: "10 - Polymorphism".to_string(),
-            url: "".to_string(),
+            url: String::new(),
             fields: HashMap::default(),
             stem_algorithm: None,
         };

--- a/stork-lib/src/index_v3/build/fill_intermediate_entries/data_source_readers/filepath_data_source_reader.rs
+++ b/stork-lib/src/index_v3/build/fill_intermediate_entries/data_source_readers/filepath_data_source_reader.rs
@@ -12,7 +12,7 @@ pub(crate) fn read(
     config: &ReaderConfig,
 ) -> Result<ReadResult, WordListGenerationError> {
     let base_directory_path = Path::new(&config.global.base_directory);
-    let full_pathname = base_directory_path.join(&path);
+    let full_pathname = base_directory_path.join(path);
 
     let file = File::open(&full_pathname)
         .map_err(|_| WordListGenerationError::FileNotFound(full_pathname.clone()))?;

--- a/stork-lib/src/index_v3/build/fill_intermediate_entries/frontmatter.rs
+++ b/stork-lib/src/index_v3/build/fill_intermediate_entries/frontmatter.rs
@@ -22,7 +22,7 @@ pub fn parse_frontmatter(handling: &FrontmatterConfig, buffer: &str) -> (Fields,
                     .into_iter()
                     .map(|(k, v)| {
                         (
-                            k.into_string().unwrap_or_else(|| "".to_string()),
+                            k.into_string().unwrap_or_default(),
                             v.clone().into_string().unwrap_or_else(|| {
                                 v.into_i64().map_or("error".to_string(), |i| i.to_string())
                             }),

--- a/stork-lib/src/index_v3/build/fill_intermediate_entries/mod.rs
+++ b/stork-lib/src/index_v3/build/fill_intermediate_entries/mod.rs
@@ -198,7 +198,7 @@ fn truncate_with_ellipsis_to_length(
             ellipsis
         };
 
-        format!("{}{}", short_message, ellipsis)
+        format!("{short_message}{ellipsis}")
     };
 
     truncated
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn break_on_file_error_breaks() {
         let invalid_file = File {
-            explicit_source: Some(DataSource::Contents("".to_string())), // Empty word list error,
+            explicit_source: Some(DataSource::Contents(String::new())), // Empty word list error,
             ..File::default()
         };
 
@@ -243,14 +243,14 @@ mod tests {
                 &WordListGenerationError::EmptyWordList
             );
         } else {
-            panic!("Result is {:?}", r);
+            panic!("Result is {r:?}");
         }
     }
 
     #[test]
     fn false_break_on_file_error_does_not_break() {
         let invalid_file = File {
-            explicit_source: Some(DataSource::Contents("".to_string())), // Empty word list error
+            explicit_source: Some(DataSource::Contents(String::new())), // Empty word list error
             ..File::default()
         };
 

--- a/stork-lib/src/index_v3/build/fill_intermediate_entries/word_list_generators/html_word_list_generator.rs
+++ b/stork-lib/src/index_v3/build/fill_intermediate_entries/word_list_generators/html_word_list_generator.rs
@@ -70,7 +70,7 @@ pub fn generate(
             for elem in as_node.traverse_inclusive() {
                 if let kuchiki::iter::NodeEdge::Start(node_ref) = elem {
                     let contents: String = (|| {
-                        let mut output = "".to_string();
+                        let mut output = String::new();
                         if let Some(element_data) = node_ref.as_element() {
                             if config.output.save_nearest_html_id {
                                 if let Some(id) = element_data.attributes.borrow().get("id") {

--- a/stork-lib/src/index_v3/build/intermediate_entry.rs
+++ b/stork-lib/src/index_v3/build/intermediate_entry.rs
@@ -39,7 +39,7 @@ mod tests {
         fields.insert("k2".to_string(), "v2".to_string());
 
         let intended = Entry {
-            contents: "".to_string(),
+            contents: String::new(),
             title: "My Title".to_string(),
             url: "https://example.com".to_string(),
             fields: fields.clone(),

--- a/stork-lib/src/index_v3/build/mod.rs
+++ b/stork-lib/src/index_v3/build/mod.rs
@@ -56,7 +56,7 @@ pub fn build(config: &Config) -> Result<BuildResult, IndexGenerationError> {
         .map(Entry::from)
         .map(|mut entry| {
             if config.output.excerpts_per_result == 0 {
-                entry.contents = "".to_string();
+                entry.contents = String::new();
             }
 
             entry
@@ -108,7 +108,7 @@ mod tests {
 
     fn generate_invalid_file_missing_selector() -> File {
         File {
-            explicit_source: Some(DataSource::Contents("".to_string())),
+            explicit_source: Some(DataSource::Contents(String::new())),
             title: "Missing Selector".to_string(),
             filetype: Some(Filetype::HTML),
             html_selector_override: Some(".article".to_string()),
@@ -118,7 +118,7 @@ mod tests {
 
     fn generate_invalid_file_empty_contents() -> File {
         File {
-            explicit_source: Some(DataSource::Contents("".to_string())),
+            explicit_source: Some(DataSource::Contents(String::new())),
             title: "Empty Contents".to_string(),
             filetype: Some(Filetype::PlainText),
             ..File::default()

--- a/stork-lib/src/index_v3/search/entry_and_intermediate_excerpts.rs
+++ b/stork-lib/src/index_v3/search/entry_and_intermediate_excerpts.rs
@@ -148,7 +148,7 @@ impl From<EntryAndIntermediateExcerpts> for Result {
             .iter()
             .filter(|&ie| ie.source == WordListSource::Title)
             .map(|ie| {
-                let space_offset = if ie.word_index == 0 { 0 } else { 1 };
+                let space_offset: usize = (ie.word_index != 0).into();
                 let beginning = split_title[0..ie.word_index].join(" ").len() + space_offset;
                 HighlightRange {
                     beginning,
@@ -206,7 +206,7 @@ mod tests {
     fn result_with_multiple_excerpts_sorts_higher_than_result_with_single() {
         let multiple_excerpts = EntryAndIntermediateExcerpts {
             entry: Entry {
-                contents: "".to_string(),
+                contents: String::new(),
                 title: "The quick brown fox jumps over the lazy dog".to_string(),
                 url: String::default(),
                 fields: HashMap::default(),
@@ -236,7 +236,7 @@ mod tests {
 
         let single_excerpt = EntryAndIntermediateExcerpts {
             entry: Entry {
-                contents: "".to_string(),
+                contents: String::new(),
                 title: "The quick brown fox jumps over the lazy dog".to_string(),
                 url: String::default(),
                 fields: HashMap::default(),
@@ -264,7 +264,7 @@ mod tests {
     fn title_highlight_ranges_are_sorted() {
         let entry_and_intermediate_excerpts = EntryAndIntermediateExcerpts {
             entry: Entry {
-                contents: "".to_string(),
+                contents: String::new(),
                 title: "The quick brown fox jumps over the lazy dog".to_string(),
                 url: String::default(),
                 fields: HashMap::default(),
@@ -293,7 +293,7 @@ mod tests {
         };
         let output_result = Result::from(entry_and_intermediate_excerpts);
         let title_highlight_ranges = output_result.title_highlight_ranges;
-        println!("{:?}", title_highlight_ranges);
+        println!("{title_highlight_ranges:?}");
         assert!(
             title_highlight_ranges[0].beginning <= title_highlight_ranges[1].beginning,
             "Title highlight ranges were not sorted! [0].beginning is {} while [1].beginning is {}",
@@ -394,7 +394,7 @@ mod tests {
     fn title_highlighting_works_when_title_has_no_spaces() {
         let entry_and_intermediate_excerpts = EntryAndIntermediateExcerpts {
             entry: Entry {
-                contents: "".to_string(),
+                contents: String::new(),
                 title: "api-methods-animate".to_string(),
                 url: String::default(),
                 fields: HashMap::default(),

--- a/stork-lib/src/lib.rs
+++ b/stork-lib/src/lib.rs
@@ -171,7 +171,7 @@ impl Display for IndexDescription {
   - {} bytes per entry
   - {} bytes per search term"#,
             if self.warnings.is_empty() {
-                "".to_string()
+                String::new()
             } else {
                 DocumentError::display_list(&self.warnings) + "\n"
             },

--- a/stork-wasm/src/lib.rs
+++ b/stork-wasm/src/lib.rs
@@ -19,7 +19,7 @@ struct WasmOutput(String);
 impl<T: Sized + Serialize, E: Display> From<Result<T, E>> for WasmOutput {
     fn from(r: Result<T, E>) -> Self {
         fn wasm_format_error<E: Display>(e: E) -> String {
-            format!("{{\"error\": \"{}\"}}", e)
+            format!("{{\"error\": \"{e}\"}}")
         }
 
         let value = match r {


### PR DESCRIPTION
- minutes_and_seconds is a supported config value
- template string expects `{}` instead of `{ts}`

Closes #330 